### PR TITLE
fix: Transaction RLP length

### DIFF
--- a/lib/src/block_builder.rs
+++ b/lib/src/block_builder.rs
@@ -286,7 +286,6 @@ where
 
             // Add receipt and tx to tries
             let trie_key = tx_no.to_rlp();
-            dbg!(tx_no, &tx);
             tx_trie
                 .insert_rlp(&trie_key, tx)
                 .context("failed to insert transaction")?;


### PR DESCRIPTION
Fixes a bug in #7 where calculating the RLP length of a transaction could return a value greater than the actual length.
This PR also adds a test that failed in the previous version.