### PR TITLE
fix: update fs write and thread sleep to async versions

### DIFF
--- a/host/src/main.rs
+++ b/host/src/main.rs
@@ -264,10 +264,11 @@ async fn main() -> Result<()> {
             let sys_time = std::time::SystemTime::now()
                 .duration_since(std::time::UNIX_EPOCH)
                 .unwrap();
-            std::fs::write(
+            tokio::fs::write(
                 format!("profile_{}.pb", sys_time.as_secs()),
                 &profiler.encode_to_vec(),
             )
+            .await
             .expect("Failed to write profiling output");
         }
 
@@ -342,7 +343,7 @@ async fn main() -> Result<()> {
                 .status(&client)
                 .expect("Could not fetch Bonsai status");
             if res.status == "RUNNING" {
-                std::thread::sleep(std::time::Duration::from_secs(15));
+                tokio::time::sleep(std::time::Duration::from_secs(15)).await;
                 continue;
             }
             if res.status == "SUCCEEDED" {


### PR DESCRIPTION
I was skimming code and noticed this. Doesn't matter now since nothing is being executed async (didn't look in depth), but it is a good future proof if there is in order not to block the executor.

Alternatively, since it seems like nothing needs to be async, this could be done to remove the runtime until it's needed:

```diff
diff --git a/host/src/main.rs b/host/src/main.rs
index d0809fc..8b97021 100644
--- a/host/src/main.rs
+++ b/host/src/main.rs
@@ -82,8 +82,7 @@ fn cache_file_path(cache_path: &String, network: &String, block_no: u64, ext: &s
     format!("{}/{}/{}.{}", cache_path, network, block_no, ext)
 }

-#[tokio::main]
-async fn main() -> Result<()> {
+fn main() -> Result<()> {
     env_logger::init();
     let args = Args::parse();

@@ -93,11 +92,8 @@ async fn main() -> Result<()> {
         .as_ref()
         .map(|dir| cache_file_path(dir, &args.network.to_string(), args.block_no, "json.gz"));

-    let init = tokio::task::spawn_blocking(move || {
-        zeth_lib::host::get_initial_data(rpc_cache, args.rpc_url, args.block_no)
-            .expect("Could not init")
-    })
-    .await?;
+    let init = zeth_lib::host::get_initial_data(rpc_cache, args.rpc_url, args.block_no)
+        .expect("Could not init");

     let input: Input = init.clone().into();
```

I'm assuming this was made to be async because maybe there is a plan to change the bonsai HTTP calls to async or have more logic be handled in parallel in the future, which is why I suggested the change I PRed.

Feel free to close; this change doesn't matter right now. I just figured I'd point it out!