### PR TITLE
build: Bump alloy to "0.3.3"

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -56,8 +56,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-primitives"
-version = "0.3.1"
-source = "git+https://github.com/alloy-rs/core.git?rev=58e2259#58e2259a858f9a1ac7ebb0eb421dce5bb6305850"
+version = "0.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e416903084d3392ebd32d94735c395d6709415b76c7728e594d3f996f2b03e65"
 dependencies = [
  "alloy-rlp",
  "bytes",

--- a/guests/eth-block/Cargo.lock
+++ b/guests/eth-block/Cargo.lock
@@ -39,8 +39,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-primitives"
-version = "0.3.1"
-source = "git+https://github.com/alloy-rs/core.git?rev=58e2259#58e2259a858f9a1ac7ebb0eb421dce5bb6305850"
+version = "0.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e416903084d3392ebd32d94735c395d6709415b76c7728e594d3f996f2b03e65"
 dependencies = [
  "alloy-rlp",
  "bytes",

--- a/lib/src/input.rs
+++ b/lib/src/input.rs
@@ -18,7 +18,7 @@ use hashbrown::HashMap;
 use revm::primitives::B160 as RevmB160;
 use serde::{Deserialize, Serialize};
 use zeth_primitives::{
-    block::Header, transaction::Transaction, trie::MptNode, withdrawal::Withdrawal, Bytes, B160,
+    block::Header, transaction::Transaction, trie::MptNode, withdrawal::Withdrawal, Address, Bytes,
     B256, U256,
 };
 
@@ -30,7 +30,7 @@ pub struct Input {
     /// Previous block header
     pub parent_header: Header,
     /// Address to which all priority fees in this block are transferred.
-    pub beneficiary: B160,
+    pub beneficiary: Address,
     /// Scalar equal to the current limit of gas expenditure per block.
     pub gas_limit: U256,
     /// Scalar corresponding to the seconds since Epoch at this block's inception.

--- a/primitives/Cargo.toml
+++ b/primitives/Cargo.toml
@@ -4,7 +4,7 @@ version = "0.1.0"
 edition = "2021"
 
 [dependencies]
-alloy-primitives = { git = "https://github.com/alloy-rs/core.git", rev = "58e2259", features = ["rlp", "serde"] }
+alloy-primitives = { version = "0.3", features = ["rlp", "serde"] }
 alloy-rlp = { version = "0.3", default-features = false }
 alloy-rlp-derive = { version = "0.3", default-features = false }
 anyhow = "1.0"

--- a/primitives/src/access_list.rs
+++ b/primitives/src/access_list.rs
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use alloy_primitives::{StorageKey, B160};
+use alloy_primitives::{Address, StorageKey};
 use alloy_rlp_derive::{RlpEncodable, RlpEncodableWrapper};
 use serde::{Deserialize, Serialize};
 
@@ -32,7 +32,7 @@ pub struct AccessList(pub Vec<AccessListItem>);
 #[derive(Debug, Clone, PartialEq, Eq, Default, RlpEncodable, Serialize, Deserialize)]
 pub struct AccessListItem {
     /// The Ethereum address that the transaction will access.
-    pub address: B160,
+    pub address: Address,
     /// A list of storage keys associated with the given address that the transaction will
     /// access.
     pub storage_keys: Vec<StorageKey>,

--- a/primitives/src/block.rs
+++ b/primitives/src/block.rs
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use alloy_primitives::{b256, BlockHash, BlockNumber, Bloom, Bytes, B160, B256, B64, U256};
+use alloy_primitives::{b256, Address, BlockHash, BlockNumber, Bloom, Bytes, B256, B64, U256};
 use alloy_rlp_derive::RlpEncodable;
 use serde::{Deserialize, Serialize};
 
@@ -30,7 +30,7 @@ pub struct Header {
     /// Unused 256-bit hash, always [EMPTY_LIST_HASH].
     pub ommers_hash: B256,
     /// Address that receives the priority fees of each transaction in the block.
-    pub beneficiary: B160,
+    pub beneficiary: Address,
     /// Root hash of the state trie after all transactions in the block are executed.
     pub state_root: B256,
     /// Root hash of the trie containing all transactions in the block.
@@ -69,7 +69,7 @@ impl Default for Header {
         Header {
             parent_hash: B256::ZERO,
             ommers_hash: EMPTY_LIST_HASH,
-            beneficiary: B160::ZERO,
+            beneficiary: Address::ZERO,
             state_root: EMPTY_ROOT,
             transactions_root: EMPTY_ROOT,
             receipts_root: EMPTY_ROOT,

--- a/primitives/src/ethers.rs
+++ b/primitives/src/ethers.rs
@@ -14,7 +14,7 @@
 
 //! Convert from Ethers types.
 
-use alloy_primitives::{Bloom, B160, B256, U256};
+use alloy_primitives::{Address, Bloom, B256, U256};
 use anyhow::{anyhow, Context};
 use ethers_core::types::{
     transaction::eip2930::{
@@ -41,9 +41,9 @@ pub fn from_ethers_u256(v: EthersU256) -> U256 {
     U256::from_limbs(v.0)
 }
 
-/// Convert an `EthersH160` type to the `B160` type.
+/// Convert an `EthersH160` type to the `Address` type.
 #[inline]
-pub fn from_ethers_h160(v: EthersH160) -> B160 {
+pub fn from_ethers_h160(v: EthersH160) -> Address {
     v.0.into()
 }
 

--- a/primitives/src/receipt.rs
+++ b/primitives/src/receipt.rs
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use alloy_primitives::{Bloom, BloomInput, Bytes, B160, B256, U256};
+use alloy_primitives::{Address, Bloom, BloomInput, Bytes, B256, U256};
 use alloy_rlp::Encodable;
 use alloy_rlp_derive::RlpEncodable;
 use serde::{Deserialize, Serialize};
@@ -21,7 +21,7 @@ use serde::{Deserialize, Serialize};
 #[derive(Debug, Clone, PartialEq, Eq, Default, Serialize, Deserialize, RlpEncodable)]
 pub struct Log {
     /// Contract that emitted this log.
-    pub address: B160,
+    pub address: Address,
     /// Topics of the log. The number of logs depend on what `LOG` opcode is used.
     pub topics: Vec<B256>,
     /// Arbitrary length data.

--- a/primitives/src/revm.rs
+++ b/primitives/src/revm.rs
@@ -25,7 +25,7 @@ use crate::{
 /// Converts a `Address` type to its corresponding `RevmB160` representation.
 #[inline]
 pub fn to_revm_b160(v: Address) -> RevmB160 {
-    v.0 .0.into()
+    v.into_array().into()
 }
 
 /// Converts a `B256` type to its corresponding `RevmB256` representation.

--- a/primitives/src/revm.rs
+++ b/primitives/src/revm.rs
@@ -14,7 +14,7 @@
 
 //! Convert to revm types.
 
-use alloy_primitives::{B160, B256};
+use alloy_primitives::{Address, B256};
 use revm_primitives::{Log as RevmLog, B160 as RevmB160, B256 as RevmB256, U256 as RevmU256};
 
 use crate::{
@@ -22,10 +22,10 @@ use crate::{
     receipt::Log,
 };
 
-/// Converts a `B160` type to its corresponding `RevmB160` representation.
+/// Converts a `Address` type to its corresponding `RevmB160` representation.
 #[inline]
-pub fn to_revm_b160(v: B160) -> RevmB160 {
-    v.0.into()
+pub fn to_revm_b160(v: Address) -> RevmB160 {
+    v.0 .0.into()
 }
 
 /// Converts a `B256` type to its corresponding `RevmB256` representation.
@@ -34,9 +34,9 @@ pub fn to_revm_b256(v: B256) -> RevmB256 {
     v.0.into()
 }
 
-/// Converts a `RevmB160` type to its corresponding `B160` representation.
+/// Converts a `RevmB160` type to its corresponding `Address` representation.
 #[inline]
-pub fn from_revm_b160(v: RevmB160) -> B160 {
+pub fn from_revm_b160(v: RevmB160) -> Address {
     v.0.into()
 }
 

--- a/primitives/src/signature.rs
+++ b/primitives/src/signature.rs
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use alloy_primitives::{B160, U256};
+use alloy_primitives::{Address, U256};
 use alloy_rlp_derive::{RlpEncodable, RlpMaxEncodedLen};
 use anyhow::Context;
 use k256::{
@@ -52,7 +52,7 @@ impl Transaction {
     /// This method uses the ECDSA recovery mechanism to derive the sender's public key
     /// and subsequently their Ethereum address. If the recovery is unsuccessful, an
     /// error is returned.
-    pub fn recover_from(&self) -> anyhow::Result<B160> {
+    pub fn recover_from(&self) -> anyhow::Result<Address> {
         let is_y_odd = self.is_y_odd().context("v invalid")?;
         let signature = K256Signature::from_scalars(
             self.signature.r.to_be_bytes(),
@@ -73,7 +73,7 @@ impl Transaction {
         debug_assert_eq!(public_key[0], 0x04);
         let hash = keccak(&public_key[1..]);
 
-        Ok(B160::from_slice(&hash[12..]))
+        Ok(Address::from_slice(&hash[12..]))
     }
 
     /// Determines whether the y-coordinate of the ECDSA signature's associated public key

--- a/primitives/src/transaction.rs
+++ b/primitives/src/transaction.rs
@@ -513,6 +513,7 @@ fn rlp_join_lists(a: impl Encodable, b: impl Encodable, out: &mut dyn alloy_rlp:
 
 #[cfg(test)]
 mod tests {
+    use alloy_primitives::{address, fixed_bytes};
     use serde_json::json;
 
     use super::*;
@@ -545,13 +546,13 @@ mod tests {
             bincode::deserialize(&bincode::serialize(&transaction).unwrap()).unwrap();
 
         assert_eq!(
-            "0x5c504ed432cb51138bcf09aa5e8a410dd4a1e204ef84bfed1be16dfba1b22060",
-            transaction.hash().to_string()
+            transaction.hash(),
+            fixed_bytes!("5c504ed432cb51138bcf09aa5e8a410dd4a1e204ef84bfed1be16dfba1b22060")
         );
         let recovered = transaction.recover_from().unwrap();
         assert_eq!(
-            "0xa1e4380a3b1f749673e270229993ee55f35663b4",
-            recovered.to_string()
+            recovered,
+            address!("a1e4380a3b1f749673e270229993ee55f35663b4")
         );
     }
 
@@ -584,13 +585,13 @@ mod tests {
             bincode::deserialize(&bincode::serialize(&transaction).unwrap()).unwrap();
 
         assert_eq!(
-            "0x4540eb9c46b1654c26353ac3c65e56451f711926982ce1b02f15c50e7459caf7",
-            transaction.hash().to_string()
+            transaction.hash(),
+            fixed_bytes!("4540eb9c46b1654c26353ac3c65e56451f711926982ce1b02f15c50e7459caf7")
         );
         let recovered = transaction.recover_from().unwrap();
         assert_eq!(
-            "0x974caa59e49682cda0ad2bbe82983419a2ecc400",
-            recovered.to_string()
+            recovered,
+            address!("974caa59e49682cda0ad2bbe82983419a2ecc400")
         );
     }
 
@@ -660,13 +661,13 @@ mod tests {
             bincode::deserialize(&bincode::serialize(&transaction).unwrap()).unwrap();
 
         assert_eq!(
-            "0xbe4ef1a2244e99b1ef518aec10763b61360be22e3b649dcdf804103719b1faef",
-            transaction.hash().to_string()
+            transaction.hash(),
+            fixed_bytes!("be4ef1a2244e99b1ef518aec10763b61360be22e3b649dcdf804103719b1faef")
         );
         let recovered = transaction.recover_from().unwrap();
         assert_eq!(
-            "0x79b7a69d90c82e014bf0315e164208119b510fa0",
-            recovered.to_string()
+            recovered,
+            address!("79b7a69d90c82e014bf0315e164208119b510fa0")
         );
     }
 
@@ -701,13 +702,13 @@ mod tests {
             bincode::deserialize(&bincode::serialize(&transaction).unwrap()).unwrap();
 
         assert_eq!(
-            "0x2bcdc03343ca9c050f8dfd3c87f32db718c762ae889f56762d8d8bdb7c5d69ff",
-            transaction.hash().to_string()
+            transaction.hash(),
+            fixed_bytes!("2bcdc03343ca9c050f8dfd3c87f32db718c762ae889f56762d8d8bdb7c5d69ff")
         );
         let recovered = transaction.recover_from().unwrap();
         assert_eq!(
-            "0x4b9f4114d50e7907bff87728a060ce8d53bf4cf7",
-            recovered.to_string()
+            recovered,
+            address!("4b9f4114d50e7907bff87728a060ce8d53bf4cf7")
         );
     }
 

--- a/primitives/src/transaction.rs
+++ b/primitives/src/transaction.rs
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use alloy_primitives::{Bytes, ChainId, TxHash, TxNumber, B160, B256, U256};
+use alloy_primitives::{Address, Bytes, ChainId, TxHash, TxNumber, B256, U256};
 use alloy_rlp::{Encodable, EMPTY_STRING_CODE};
 use alloy_rlp_derive::RlpEncodable;
 use serde::{Deserialize, Serialize};
@@ -312,16 +312,16 @@ pub enum TransactionKind {
     Create,
     /// Indicates that the transaction is a call to an existing contract, identified by
     /// its 160-bit address.
-    Call(B160),
+    Call(Address),
 }
 
-/// Provides a conversion from [TransactionKind] to `Option<B160>`.
+/// Provides a conversion from [TransactionKind] to `Option<Address>`.
 ///
 /// This implementation allows for a straightforward extraction of the Ethereum address
 /// from a [TransactionKind]. If the transaction kind is a `Call`, the address is wrapped
 /// in a `Some`. If it's a `Create`, the result is `None`.
-impl From<TransactionKind> for Option<B160> {
-    /// Converts a [TransactionKind] into an `Option<B160>`.
+impl From<TransactionKind> for Option<Address> {
+    /// Converts a [TransactionKind] into an `Option<Address>`.
     ///
     /// - If the transaction kind is `Create`, this returns `None`.
     /// - If the transaction kind is `Call`, this returns the address wrapped in a `Some`.
@@ -461,7 +461,7 @@ impl Transaction {
     ///
     /// For contract creation transactions, this method returns `None` as there's no
     /// recipient address.
-    pub fn to(&self) -> Option<B160> {
+    pub fn to(&self) -> Option<Address> {
         match &self.essence {
             TxEssence::Legacy(tx) => tx.to.into(),
             TxEssence::Eip2930(tx) => tx.to.into(),

--- a/primitives/src/withdrawal.rs
+++ b/primitives/src/withdrawal.rs
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use alloy_primitives::B160;
+use alloy_primitives::Address;
 use alloy_rlp_derive::{RlpEncodable, RlpMaxEncodedLen};
 use serde::{Deserialize, Serialize};
 
@@ -32,9 +32,9 @@ pub struct Withdrawal {
     pub index: u64,
     /// The distinct index of the validator initiating this withdrawal.
     pub validator_index: u64,
-    /// The Ethereum address, encapsulated as a `B160` type, where the withdrawn ether
+    /// The Ethereum address, encapsulated as a `Address` type, where the withdrawn ether
     /// will be sent.
-    pub address: B160,
+    pub address: Address,
     /// The total withdrawal amount, denominated in gwei.
     pub amount: u64,
 }

--- a/testing/ef-tests/src/ethers.rs
+++ b/testing/ef-tests/src/ethers.rs
@@ -43,7 +43,7 @@ impl Provider for TestProvider {
         Ok(Block::<H256> {
             parent_hash: self.header.parent_hash.0.into(),
             uncles_hash: self.header.ommers_hash.0.into(),
-            author: Some(self.header.beneficiary.0 .0.into()),
+            author: Some(self.header.beneficiary.into_array().into()),
             state_root: self.header.state_root.0.into(),
             transactions_root: self.header.transactions_root.0.into(),
             receipts_root: self.header.receipts_root.0.into(),
@@ -189,7 +189,7 @@ fn get_proof(
     }
 
     Ok(EIP1186ProofResponse {
-        address: address.0 .0.into(),
+        address: address.into_array().into(),
         balance: account.balance.to_be_bytes().into(),
         code_hash: keccak(account.code).into(),
         nonce: account.nonce.to_be_bytes().into(),

--- a/testing/ef-tests/src/ethers.rs
+++ b/testing/ef-tests/src/ethers.rs
@@ -43,7 +43,7 @@ impl Provider for TestProvider {
         Ok(Block::<H256> {
             parent_hash: self.header.parent_hash.0.into(),
             uncles_hash: self.header.ommers_hash.0.into(),
-            author: Some(self.header.beneficiary.0.into()),
+            author: Some(self.header.beneficiary.0 .0.into()),
             state_root: self.header.state_root.0.into(),
             transactions_root: self.header.transactions_root.0.into(),
             receipts_root: self.header.receipts_root.0.into(),
@@ -126,7 +126,7 @@ impl Provider for TestProvider {
     }
 }
 
-fn build_tries(state: &TestState) -> (MptNode, HashMap<B160, MptNode>) {
+fn build_tries(state: &TestState) -> (MptNode, HashMap<Address, MptNode>) {
     let mut state_trie = MptNode::default();
     let mut storage_tries = HashMap::new();
     for (address, account) in &state.0 {
@@ -157,7 +157,7 @@ fn build_tries(state: &TestState) -> (MptNode, HashMap<B160, MptNode>) {
 }
 
 fn get_proof(
-    address: B160,
+    address: Address,
     indices: impl IntoIterator<Item = LibU256>,
     state: &TestState,
 ) -> Result<EIP1186ProofResponse, anyhow::Error> {
@@ -189,7 +189,7 @@ fn get_proof(
     }
 
     Ok(EIP1186ProofResponse {
-        address: address.0.into(),
+        address: address.0 .0.into(),
         balance: account.balance.to_be_bytes().into(),
         code_hash: keccak(account.code).into(),
         nonce: account.nonce.to_be_bytes().into(),

--- a/testing/ef-tests/src/lib.rs
+++ b/testing/ef-tests/src/lib.rs
@@ -44,7 +44,7 @@ use zeth_primitives::{
     },
     trie::{self, MptNode, MptNodeData, StateAccount},
     withdrawal::Withdrawal,
-    Bloom, Bytes, RlpBytes, StorageKey, B160, B256, B64, U256, U64,
+    Address, Bloom, Bytes, RlpBytes, StorageKey, B256, B64, U256, U64,
 };
 
 use crate::ethers::{get_state_update_proofs, TestProvider};
@@ -106,7 +106,7 @@ impl From<DbAccount> for TestAccount {
 
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
 #[serde(rename_all = "camelCase")]
-pub struct TestState(pub HashMap<B160, TestAccount>);
+pub struct TestState(pub HashMap<Address, TestAccount>);
 
 impl From<&MemDb> for TestState {
     fn from(db: &MemDb) -> Self {
@@ -130,7 +130,7 @@ impl From<&ProviderDb> for TestState {
 pub struct TestHeader {
     pub base_fee_per_gas: Option<U256>,
     pub bloom: Bloom,
-    pub coinbase: B160,
+    pub coinbase: Address,
     pub extra_data: Bytes,
     pub difficulty: U256,
     pub gas_limit: U256,
@@ -184,7 +184,7 @@ pub struct TestTransaction {
     pub max_priority_fee_per_gas: Option<U256>,
     pub value: U256,
     #[serde_as(as = "NoneAsEmptyString")]
-    pub to: Option<B160>,
+    pub to: Option<Address>,
     pub nonce: U64,
     pub v: U64,
     pub r: U256,
@@ -252,7 +252,7 @@ pub struct TestAccessList(pub Vec<TestAccessListItem>);
 #[derive(Debug, Clone, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]
 pub struct TestAccessListItem {
-    pub address: B160,
+    pub address: Address,
     pub storage_keys: Vec<StorageKey>,
 }
 

--- a/testing/ef-tests/testguest/Cargo.lock
+++ b/testing/ef-tests/testguest/Cargo.lock
@@ -39,8 +39,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-primitives"
-version = "0.3.1"
-source = "git+https://github.com/alloy-rs/core.git?rev=58e2259#58e2259a858f9a1ac7ebb0eb421dce5bb6305850"
+version = "0.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e416903084d3392ebd32d94735c395d6709415b76c7728e594d3f996f2b03e65"
 dependencies = [
  "alloy-rlp",
  "bytes",


### PR DESCRIPTION
Upgrades `alloy-primitives` to `v0.3.3`.
This new version deprecates `B160` in favor of `Address`. While we technically don't need the advanced features `Address` brings, it doesn't hurt either.