### PR TITLE
Introduce op-info tool

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -113,6 +113,35 @@ dependencies = [
 ]
 
 [[package]]
+name = "alloy-sol-macro"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8a98ad1696a2e17f010ae8e43e9f2a1e930ed176a8e3ff77acfeff6dfb07b42c"
+dependencies = [
+ "const-hex",
+ "dunce",
+ "heck",
+ "proc-macro-error",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.38",
+ "syn-solidity",
+ "tiny-keccak",
+]
+
+[[package]]
+name = "alloy-sol-types"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "98d7107bed88e8f09f0ddcc3335622d87bfb6821f3e0c7473329fb1cfad5e015"
+dependencies = [
+ "alloy-primitives",
+ "alloy-sol-macro",
+ "const-hex",
+ "serde",
+]
+
+[[package]]
 name = "android-tzdata"
 version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1001,6 +1030,12 @@ name = "downcast-rs"
 version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9ea835d29036a4087793836fa931b08837ad5e957da9e23886b29586fb9b6650"
+
+[[package]]
+name = "dunce"
+version = "1.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "56ce8c6da7551ec6c462cbaf3bfbc75131ebbfa1c944aeaa9dab51ca1c5f0c3b"
 
 [[package]]
 name = "ecdsa"
@@ -3777,6 +3812,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "syn-solidity"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "86b837ef12ab88835251726eb12237655e61ec8dc8a280085d1961cdc3dfd047"
+dependencies = [
+ "paste",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.38",
+]
+
+[[package]]
 name = "system-configuration"
 version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4515,6 +4562,8 @@ dependencies = [
 name = "zeth"
 version = "0.1.0"
 dependencies = [
+ "alloy-sol-macro",
+ "alloy-sol-types",
  "anyhow",
  "assert_cmd",
  "bincode",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4562,7 +4562,6 @@ dependencies = [
 name = "zeth"
 version = "0.1.0"
 dependencies = [
- "alloy-sol-macro",
  "alloy-sol-types",
  "anyhow",
  "assert_cmd",

--- a/host/Cargo.toml
+++ b/host/Cargo.toml
@@ -4,6 +4,8 @@ version = "0.1.0"
 edition = "2021"
 
 [dependencies]
+alloy-sol-macro = { version = "0.4" }
+alloy-sol-types = { version = "0.4" }
 anyhow = "1.0"
 bincode = "1.3.3"
 bonsai-sdk = { workspace = true }

--- a/host/Cargo.toml
+++ b/host/Cargo.toml
@@ -4,8 +4,7 @@ version = "0.1.0"
 edition = "2021"
 
 [dependencies]
-alloy-sol-macro = { version = "0.4" }
-alloy-sol-types = { version = "0.4" }
+alloy-sol-types = "0.4"
 anyhow = "1.0"
 bincode = "1.3.3"
 bonsai-sdk = { workspace = true }

--- a/host/src/bin/op-info.rs
+++ b/host/src/bin/op-info.rs
@@ -1,0 +1,87 @@
+// Copyright 2023 RISC Zero, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use alloy_sol_types::{sol, SolInterface};
+use anyhow::Result;
+use clap::Parser;
+use zeth_lib::host::provider::{new_provider, BlockQuery};
+
+sol! {
+    #[derive(Debug)]
+    interface OpSystemInfo {
+        function setL1BlockValues(uint64 _number, uint64 _timestamp, uint256 _basefee, bytes32 _hash, uint64 _sequenceNumber, bytes32 _batcherHash, uint256 _l1FeeOverhead, uint256 _l1FeeScalar);
+    }
+}
+
+#[derive(Parser, Debug, Clone)]
+#[clap(author, version, about, long_about = None)]
+struct Args {
+    #[clap(long, require_equals = true)]
+    /// URL of the L2 RPC node.
+    op_rpc_url: Option<String>,
+
+    #[clap(short, long, require_equals = true, num_args = 0..=1, default_missing_value = "host/testdata")]
+    /// Use a local directory as a cache for RPC calls. Accepts a custom directory.
+    /// [default: host/testdata]
+    cache: Option<String>,
+
+    #[clap(long, require_equals = true)]
+    /// L2 block number to begin from
+    block_no: u64,
+}
+
+fn cache_file_path(cache_path: &String, network: &str, block_no: u64, ext: &str) -> String {
+    format!("{}/{}/{}.{}", cache_path, network, block_no, ext)
+}
+
+fn op_cache_path(args: &Args, block_no: u64) -> Option<String> {
+    args.cache
+        .as_ref()
+        .map(|dir| cache_file_path(dir, "optimism", block_no, "json.gz"))
+}
+
+#[tokio::main]
+async fn main() -> Result<()> {
+    env_logger::init();
+    let args = Args::parse();
+
+    let op_block = tokio::task::spawn_blocking(move || {
+        let mut provider =
+            new_provider(op_cache_path(&args, args.block_no), args.op_rpc_url.clone())
+                .expect("Could not create provider");
+
+        let op_block = provider
+            .get_full_block(&BlockQuery {
+                block_no: args.block_no,
+            })
+            .expect("Could not fetch OP block");
+        provider.save().expect("Could not save cache");
+
+        op_block
+    })
+    .await?;
+
+    let system_tx_data = op_block
+        .transactions
+        .first()
+        .expect("No transactions")
+        .input
+        .to_vec();
+    let set_l1_block_values = OpSystemInfo::OpSystemInfoCalls::abi_decode(&system_tx_data, true)
+        .expect("Could not decode call data");
+
+    println!("{:?}", set_l1_block_values);
+
+    Ok(())
+}

--- a/host/src/bin/op-info.rs
+++ b/host/src/bin/op-info.rs
@@ -20,7 +20,16 @@ use zeth_lib::host::provider::{new_provider, BlockQuery};
 sol! {
     #[derive(Debug)]
     interface OpSystemInfo {
-        function setL1BlockValues(uint64 _number, uint64 _timestamp, uint256 _basefee, bytes32 _hash, uint64 _sequenceNumber, bytes32 _batcherHash, uint256 _l1FeeOverhead, uint256 _l1FeeScalar);
+        function setL1BlockValues(
+            uint64 _number,
+            uint64 _timestamp,
+            uint256 _basefee,
+            bytes32 _hash,
+            uint64 _sequenceNumber,
+            bytes32 _batcherHash,
+            uint256 _l1FeeOverhead,
+            uint256 _l1FeeScalar
+        );
     }
 }
 


### PR DESCRIPTION
The `op-info` tool fetches and displays epoch information for a given Op block.

Example:

```console
$ ./target/release/op-info --op-rpc-url=[hidden] --block-no=111330600
setL1BlockValues(setL1BlockValuesCall { _number: 18429149, _timestamp: 1698259907, _basefee: 0x000000000000000000000000000000000000000000000000000000098aa55d24_U256, _hash: 0xba523e94231f321d5873d4e0a14b27455354d96af26089522a449fa686c3effc, _sequenceNumber: 0, _batcherHash: 0x0000000000000000000000006887246668a3b87f54deb3b94ba47a6f63f32985, _l1FeeOverhead: 0x00000000000000000000000000000000000000000000000000000000000000bc_U256, _l1FeeScalar: 0x00000000000000000000000000000000000000000000000000000000000a6fe0_U256 })
```

(The example data given above can be [corroborated using etherscan](https://optimistic.etherscan.io/tx/0xbc78de7dc30507f24cb210fe49edc4ad5af63255a601476f7d758092b99af539)).

Under the hood, this tool uses the [`alloy_sol_macro` crate](https://docs.rs/alloy-sol-macro/latest/alloy_sol_macro/macro.sol.html), resulting in a clean implementation. First we describe the function we care about:

```rust
use alloy_sol_types::{sol, SolInterface};

sol! {
    #[derive(Debug)]
    interface OpSystemInfo {
        function setL1BlockValues(
            uint64 _number,
            uint64 _timestamp,
            uint256 _basefee,
            bytes32 _hash,
            uint64 _sequenceNumber,
            bytes32 _batcherHash,
            uint256 _l1FeeOverhead,
            uint256 _l1FeeScalar
        );
    }
}
```

Then we parse the calldata from the transaction:

```rust
   let system_tx_data = op_block
        .transactions
        .first()
        .expect("No transactions")
        .input
        .to_vec();
    let set_l1_block_values = OpSystemInfo::OpSystemInfoCalls::abi_decode(&system_tx_data, true)
        .expect("Could not decode call data");
```