### PR TITLE
Fix frame parsing and loading in Optimism derivation

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4825,6 +4825,7 @@ dependencies = [
  "alloy-sol-types",
  "anyhow",
  "bincode",
+ "bytes",
  "chrono",
  "ethers-core",
  "ethers-providers",

--- a/guests/eth-block/Cargo.lock
+++ b/guests/eth-block/Cargo.lock
@@ -3741,6 +3741,7 @@ version = "0.1.0"
 dependencies = [
  "alloy-sol-types",
  "anyhow",
+ "bytes",
  "chrono",
  "ethers-core",
  "ethers-providers",

--- a/guests/op-block/Cargo.lock
+++ b/guests/op-block/Cargo.lock
@@ -3741,6 +3741,7 @@ version = "0.1.0"
 dependencies = [
  "alloy-sol-types",
  "anyhow",
+ "bytes",
  "chrono",
  "ethers-core",
  "ethers-providers",

--- a/guests/op-derive/Cargo.lock
+++ b/guests/op-derive/Cargo.lock
@@ -3706,6 +3706,7 @@ version = "0.1.0"
 dependencies = [
  "alloy-sol-types",
  "anyhow",
+ "bytes",
  "chrono",
  "ethers-core",
  "ethers-providers",

--- a/lib/Cargo.toml
+++ b/lib/Cargo.toml
@@ -6,6 +6,7 @@ edition = "2021"
 [dependencies]
 alloy-sol-types = "0.4"
 anyhow = "1.0"
+bytes = "1.5"
 ethers-core = { version = "2.0", features = ["optimism"] }
 hashbrown = { workspace = true }
 libflate = "2.0.0"

--- a/lib/src/optimism/batcher_channel.rs
+++ b/lib/src/optimism/batcher_channel.rs
@@ -69,6 +69,9 @@ impl BatcherChannels {
                 continue;
             }
 
+            #[cfg(not(target_os = "zkvm"))]
+            log::debug!("received batcher tx: {}", tx.hash());
+
             for frame in Frame::process_batcher_transaction(&tx.essence)? {
                 #[cfg(not(target_os = "zkvm"))]
                 log::debug!(

--- a/lib/src/optimism/batcher_channel.rs
+++ b/lib/src/optimism/batcher_channel.rs
@@ -240,10 +240,8 @@ impl Channel {
         let mut batches = Vec::new();
 
         while !channel_data.is_empty() {
-            let batch_data = Header::decode_bytes(&mut channel_data, false)
-                .context("failed to decode batch data")?;
-
-            let mut batch = Batch::decode(&mut &batch_data[..])?;
+            let mut batch =
+                Batch::decode(&mut channel_data).context("failed to decode batch data")?;
             batch.inclusion_block_number = l1_block_number;
 
             batches.push(batch);

--- a/lib/src/optimism/batcher_channel.rs
+++ b/lib/src/optimism/batcher_channel.rs
@@ -22,7 +22,7 @@ use bytes::Buf;
 use libflate::zlib::Decoder;
 use zeth_primitives::{
     batch::Batch,
-    rlp::{Decodable},
+    rlp::Decodable,
     transactions::{ethereum::EthereumTxEssence, Transaction, TxEssence},
     Address, BlockNumber,
 };

--- a/primitives/src/batch.rs
+++ b/primitives/src/batch.rs
@@ -17,7 +17,6 @@ use std::cmp::Ordering;
 use alloy_primitives::{BlockNumber, Bytes, B256};
 use alloy_rlp::{Decodable, Encodable};
 use alloy_rlp_derive::{RlpDecodable, RlpEncodable};
-use bytes::Buf;
 
 pub type RawTransaction = Bytes;
 
@@ -72,28 +71,66 @@ impl Batch {
 impl Encodable for Batch {
     #[inline]
     fn encode(&self, out: &mut dyn alloy_rlp::BufMut) {
+        // wrap the RLP-essence inside a bytes payload
+        alloy_rlp::Header {
+            list: false,
+            payload_length: self.essence.length() + 1,
+        }
+        .encode(out);
         out.put_u8(0);
         self.essence.encode(out);
     }
 
     #[inline]
     fn length(&self) -> usize {
-        self.essence.length() + 1
+        let bytes_length = self.essence.length() + 1;
+        alloy_rlp::length_of_length(bytes_length) + bytes_length
     }
 }
 
 impl Decodable for Batch {
     fn decode(buf: &mut &[u8]) -> alloy_rlp::Result<Self> {
-        match buf.first() {
-            Some(0) => {
-                buf.advance(1);
-                Ok(Self {
-                    inclusion_block_number: 0,
-                    essence: BatchEssence::decode(buf)?,
-                })
-            }
+        let bytes = alloy_rlp::Header::decode_bytes(buf, false)?;
+        match bytes.split_first() {
+            Some((0, mut payload)) => Ok(Self {
+                inclusion_block_number: 0,
+                essence: BatchEssence::decode(&mut payload)?,
+            }),
             Some(_) => Err(alloy_rlp::Error::Custom("invalid version")),
             None => Err(alloy_rlp::Error::InputTooShort),
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use alloy_primitives::{b256, hex::FromHex};
+
+    use super::*;
+
+    #[test]
+    fn rlp_roundtrip() {
+        let batch = Batch {
+            inclusion_block_number: 0,
+            essence: BatchEssence {
+                parent_hash: b256!(
+                    "55b11b918355b1ef9c5db810302ebad0bf2544255b530cdce90674d5887bb286"
+                ),
+                epoch_num: 1,
+                epoch_hash: b256!(
+                    "1dcc4de8dec75d7aab85b567b6ccd41ad312451b948a7413f0a142fd40d49347"
+                ),
+                timestamp: 1647026951,
+                transactions: vec![
+                    Bytes::from_hex("0x000000").unwrap(),
+                    Bytes::from_hex("0x76fd7c").unwrap(),
+                ],
+            },
+        };
+
+        let encoded = alloy_rlp::encode(&batch);
+        assert_eq!(encoded.len(), batch.length());
+        let decoded = Batch::decode(&mut &encoded[..]).unwrap();
+        assert_eq!(batch, decoded);
     }
 }

--- a/testing/ef-tests/testguest/Cargo.lock
+++ b/testing/ef-tests/testguest/Cargo.lock
@@ -3741,6 +3741,7 @@ version = "0.1.0"
 dependencies = [
  "alloy-sol-types",
  "anyhow",
+ "bytes",
  "chrono",
  "ethers-core",
  "ethers-providers",


### PR DESCRIPTION
Fixes the frame parsing and frame loading according to the spec and `op-geth` ([channel.go](https://github.com/ethereum-optimism/optimism/blob/develop/op-node/rollup/derive/channel.go), [frame.go](https://github.com/ethereum-optimism/optimism/blob/develop/op-node/rollup/derive/frame.go)).

The frame loading behavior is now as follows:
- If a channel is closed:
  - additional closing frames are invalid
  - any frames with a number larger than the closing frame's number are invalid (this is not 100% clear in the spec, but it is the canonical consequence and implemented in op-geth)
- frames with duplicate numbers are invalid
- if a closing frame in ingested, prune frames with a number higher than the closing frame

This PR should address the open review questions in https://github.com/risc0/zeth/pull/51 concerning frames.