### PR TITLE
chore: Update Ethereum Execution Tests to 13.1

### DIFF
--- a/lib/src/consts.rs
+++ b/lib/src/consts.rs
@@ -156,6 +156,17 @@ impl ChainSpec {
     pub fn chain_id(&self) -> ChainId {
         self.chain_id
     }
+    /// Validates a [SpecId].
+    pub fn validate_spec_id(&self, spec_id: SpecId) -> Result<()> {
+        let (min_spec_id, _) = self.hard_forks.first_key_value().unwrap();
+        if spec_id < *min_spec_id {
+            bail!("expected >= {:?}, got {:?}", min_spec_id, spec_id);
+        }
+        if spec_id > self.max_spec_id {
+            bail!("expected <= {:?}, got {:?}", self.max_spec_id, spec_id);
+        }
+        Ok(())
+    }
     /// Returns the [SpecId] for a given block number and timestamp or an error if not
     /// supported.
     pub fn active_fork(&self, block_number: BlockNumber, timestamp: &U256) -> Result<SpecId> {

--- a/lib/src/mem_db.rs
+++ b/lib/src/mem_db.rs
@@ -200,9 +200,6 @@ impl DatabaseCommit for MemDb {
                     }
                 };
 
-                // it is not possible to delete a deleted account
-                debug_assert!(db_account.state != AccountState::Deleted);
-
                 // clear the account and mark it as deleted
                 db_account.storage.clear();
                 db_account.state = AccountState::Deleted;

--- a/testing/ef-tests/src/ethtests.rs
+++ b/testing/ef-tests/src/ethtests.rs
@@ -16,12 +16,13 @@ use std::{fs::File, io::BufReader, path::PathBuf};
 
 use revm::primitives::SpecId;
 use serde_json::Value;
-use zeth_lib::consts::{ChainSpec, ETH_MAINNET_EIP1559_CONSTANTS};
+use zeth_lib::consts::{ChainSpec, ETH_MAINNET_CHAIN_SPEC, ETH_MAINNET_EIP1559_CONSTANTS};
 use zeth_primitives::block::Header;
 
 use crate::TestJson;
 
 pub struct EthTestCase {
+    pub name: String,
     pub json: TestJson,
     pub genesis: Header,
     pub chain_spec: ChainSpec,
@@ -36,13 +37,11 @@ pub fn read_eth_test(path: PathBuf) -> Vec<EthTestCase> {
         .unwrap()
         .into_iter()
         .filter_map(|(name, test)| {
-            println!("test '{}'", name);
             let json: TestJson = serde_json::from_value(test.take()).unwrap();
 
-            let spec: SpecId = json.network.as_str().into();
-            // skip tests with an unsupported network version
-            if spec < SpecId::MERGE || spec > SpecId::SHANGHAI {
-                println!("skipping ({})", json.network);
+            let spec: SpecId = json.network.replace("Paris", "Merge").as_str().into();
+            if let Err(err) = ETH_MAINNET_CHAIN_SPEC.validate_spec_id(spec) {
+                println!("skipping '{}': {}", name, err);
                 return None;
             }
             let chain_spec = ChainSpec::new_single(1, spec, ETH_MAINNET_EIP1559_CONSTANTS);
@@ -51,6 +50,7 @@ pub fn read_eth_test(path: PathBuf) -> Vec<EthTestCase> {
             assert_eq!(genesis.hash(), json.genesis.hash);
 
             Some(EthTestCase {
+                name: name.clone(),
                 json,
                 genesis,
                 chain_spec,

--- a/testing/ef-tests/src/lib.rs
+++ b/testing/ef-tests/src/lib.rs
@@ -78,7 +78,8 @@ pub struct TestBlock {
     pub rlp: Bytes,
     #[serde(default)]
     pub transactions: Vec<TestTransaction>,
-    pub withdrawals: Option<Vec<TestWithdrawal>>,
+    #[serde(default)]
+    pub withdrawals: Vec<TestWithdrawal>,
 }
 
 #[derive(Debug, Clone, Default, Serialize, Deserialize, PartialEq, Eq)]
@@ -201,7 +202,7 @@ impl From<TestTransaction> for EthereumTransaction {
         };
         let essence = match tx.type_id.map(|v| u8::try_from(v).unwrap()) {
             None | Some(0) => EthereumTxEssence::Legacy(TxEssenceLegacy {
-                chain_id: Parity::try_from(tx.v).unwrap().chain_id(),
+                chain_id: Parity::try_from(tx.v).unwrap().chain_id(), // derive chain ID from sig
                 nonce: tx.nonce.try_into().unwrap(),
                 gas_price: tx.gas_price.unwrap(),
                 gas_limit: tx.gas_limit,

--- a/testing/ef-tests/tests/evm.rs
+++ b/testing/ef-tests/tests/evm.rs
@@ -75,7 +75,7 @@ fn evm(
             json.pre,
             expected_header.clone(),
             block.transactions,
-            block.withdrawals.unwrap_or_default(),
+            block.withdrawals,
             post_state,
         );
         let input_state_input_hash = input.state_input.hash();

--- a/testing/ef-tests/tests/evm.rs
+++ b/testing/ef-tests/tests/evm.rs
@@ -35,25 +35,31 @@ fn evm(
     path: PathBuf,
 ) {
     let _ = env_logger::builder()
-        .filter_level(log::LevelFilter::Debug)
+        .filter_level(log::LevelFilter::Trace)
         .is_test(true)
         .try_init();
 
     for EthTestCase {
+        name,
         mut json,
         genesis,
         chain_spec,
     } in read_eth_test(path)
     {
         // only one block supported for now
-        assert_eq!(json.blocks.len(), 1);
+        if json.blocks.len() > 1 {
+            println!("skipping '{}': more than one block", name);
+            continue;
+        }
         let block = json.blocks.pop().unwrap();
 
         // skip failing tests for now
         if let Some(message) = block.expect_exception {
-            println!("skipping ({})", message);
+            println!("skipping '{}': {}", name, message);
             break;
         }
+
+        println!("running '{}'", name);
 
         let block_header = block.block_header.unwrap();
         let expected_header: Header = block_header.clone().into();

--- a/testing/ef-tests/tests/evm.rs
+++ b/testing/ef-tests/tests/evm.rs
@@ -35,7 +35,7 @@ fn evm(
     path: PathBuf,
 ) {
     let _ = env_logger::builder()
-        .filter_level(log::LevelFilter::Trace)
+        .filter_level(log::LevelFilter::Debug)
         .is_test(true)
         .try_init();
 
@@ -56,7 +56,7 @@ fn evm(
         // skip failing tests for now
         if let Some(message) = block.expect_exception {
             println!("skipping '{}': {}", name, message);
-            break;
+            continue;
         }
 
         println!("running '{}'", name);

--- a/testing/ef-tests/tests/executor.rs
+++ b/testing/ef-tests/tests/executor.rs
@@ -42,6 +42,7 @@ fn executor(
         .try_init();
 
     for EthTestCase {
+        name,
         json,
         genesis,
         chain_spec,
@@ -56,6 +57,8 @@ fn executor(
             println!("skipping ({})", message);
             break;
         }
+
+        println!("running: {}", name);
 
         let block_header = block.block_header.unwrap();
         let expected_header: Header = block_header.clone().into();

--- a/testing/ef-tests/tests/executor.rs
+++ b/testing/ef-tests/tests/executor.rs
@@ -70,7 +70,7 @@ fn executor(
             json.pre,
             expected_header.clone(),
             block.transactions,
-            block.withdrawals.unwrap_or_default(),
+            block.withdrawals,
             json.post.unwrap(),
         );
 


### PR DESCRIPTION
- Handle `Merge` and `Paris` as spec.
- Load `Chain_ID` from tests instead of assuming `1`.