### PR TITLE
fix: Ensure segment dir is in-scope during proving

### DIFF
--- a/host/src/operations/mod.rs
+++ b/host/src/operations/mod.rs
@@ -311,6 +311,7 @@ pub fn prove_locally(
         encoded_input.len(),
         encoded_input.len() * 4 / 1_000_000
     );
+    let segment_dir = tempdir().unwrap();
 
     info!("Running the prover...");
     let session = {
@@ -331,8 +332,6 @@ pub fn prove_locally(
 
         let env = env_builder.build().unwrap();
         let mut exec = ExecutorImpl::from_elf(env, elf).unwrap();
-
-        let segment_dir = tempdir().unwrap();
 
         exec.run_with_callback(|segment| {
             Ok(Box::new(FileSegmentRef::new(&segment, segment_dir.path())?))


### PR DESCRIPTION
This keeps the temporary segment directory extant until proving is done.
Otherwise, the prover tries to load a segment from a deleted temporary directory - which fails.