### PR TITLE
Block cycle count collection

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -6,6 +6,7 @@
         "./guests/op-block/Cargo.toml",
         "./guests/op-compose/Cargo.toml",
         "./guests/op-derive/Cargo.toml",
+        "./host/Cargo.toml",
         "./testing/ef-tests/testguest/Cargo.toml"
     ]
 }

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -29,11 +29,20 @@ version = "0.21.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8a30b2e23b9e17a9f90641c7ab1549cd9b44f296d3ccbf309d2863cfe398a0cb"
 dependencies = [
+ "gimli 0.28.1",
+]
+
+[[package]]
+name = "addr2line"
+version = "0.22.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6e4503c46a5c0c7844e948c9a4d6acd9f50cccb4de1c48eb9e291ea17470c678"
+dependencies = [
  "cpp_demangle",
  "fallible-iterator",
- "gimli",
+ "gimli 0.29.0",
  "memmap2",
- "object",
+ "object 0.35.0",
  "rustc-demangle",
  "smallvec",
 ]
@@ -218,6 +227,15 @@ name = "anyhow"
 version = "1.0.81"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0952808a6c2afd1aa8947271f3a60f1a6763c7b912d210184c5149b5cf147247"
+
+[[package]]
+name = "arbitrary"
+version = "1.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7d5a26814d8dcb93b0e5a0ff3c6d80a8843bafb21b39e8e18a6f05471870e110"
+dependencies = [
+ "derive_arbitrary",
+]
 
 [[package]]
 name = "ark-bn254"
@@ -524,26 +542,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d468802bab17cbc0cc575e9b053f41e72aa36bfa6b7f55e3529ffa43161b97fa"
 
 [[package]]
-name = "autotools"
-version = "0.2.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "aef8da1805e028a172334c3b680f93e71126f2327622faef2ec3d893c0a4ad77"
-dependencies = [
- "cc",
-]
-
-[[package]]
 name = "backtrace"
 version = "0.3.71"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "26b05800d2e817c8b3b4b54abd461726265fa9789ae34330622f2db9ee696f9d"
 dependencies = [
- "addr2line",
+ "addr2line 0.21.0",
  "cc",
  "cfg-if",
  "libc",
  "miniz_oxide",
- "object",
+ "object 0.32.2",
  "rustc-demangle",
 ]
 
@@ -564,6 +573,12 @@ name = "base64"
 version = "0.21.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9d297deb1925b89f2ccc13d7635fa0714f12c87adce1c75356b39ca9b7178567"
+
+[[package]]
+name = "base64"
+version = "0.22.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "72b3254f16251a8381aa12e40e3c4d2f0199f8c6508fbecb9d91f575e0fbb8c6"
 
 [[package]]
 name = "base64ct"
@@ -665,7 +680,7 @@ version = "0.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d5f0a6b186dce8b2f945bd3ecc5d35a36280400200ed57878c7c3f2aeb01632e"
 dependencies = [
- "reqwest",
+ "reqwest 0.11.27",
  "serde",
  "thiserror",
  "tokio",
@@ -673,11 +688,11 @@ dependencies = [
 
 [[package]]
 name = "bonsai-sdk"
-version = "0.8.0-rc.1"
+version = "0.8.0-rc.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "731c9783854cd29c248d5ed95e9c4bef9e57368f340c6baf6cc2fa5ec0cc240f"
+checksum = "d8f46b40f7039b0bd2f568e18fad3f63d3388d343c4877147c35af610d67c337"
 dependencies = [
- "reqwest",
+ "reqwest 0.12.4",
  "risc0-groth16",
  "serde",
  "thiserror",
@@ -1124,6 +1139,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "derive_arbitrary"
+version = "1.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "67e77553c4162a157adbf834ebae5b415acbecbeafc7a74b0e886657506a7611"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.55",
+]
+
+[[package]]
 name = "derive_more"
 version = "0.99.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1200,6 +1226,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "displaydoc"
+version = "0.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "487585f4d0c6655fe74905e2504d8ad6908e4db67f744eb140876906c2f3175d"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.55",
+]
+
+[[package]]
 name = "doc-comment"
 version = "0.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1226,7 +1263,7 @@ dependencies = [
  "digest 0.10.7",
  "futures",
  "rand",
- "reqwest",
+ "reqwest 0.11.27",
  "thiserror",
  "tokio",
 ]
@@ -1521,12 +1558,12 @@ dependencies = [
  "futures-timer",
  "futures-util",
  "hashers",
- "http",
+ "http 0.2.12",
  "instant",
  "jsonwebtoken",
  "once_cell",
  "pin-project",
- "reqwest",
+ "reqwest 0.11.27",
  "serde",
  "serde_json",
  "thiserror",
@@ -1614,12 +1651,6 @@ dependencies = [
  "rustc-hex",
  "static_assertions",
 ]
-
-[[package]]
-name = "fixedbitset"
-version = "0.4.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0ce7134b9999ecaf8bcd65542e436736ef32ddca1b3e06094cb6ec5755203b80"
 
 [[package]]
 name = "flate2"
@@ -1823,6 +1854,12 @@ name = "gimli"
 version = "0.28.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4271d37baee1b8c7e4b708028c57d816cf9d2434acb33a549475f78c181f6253"
+
+[[package]]
+name = "gimli"
+version = "0.29.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "40ecd4077b5ae9fd2e9e169b102c6c330d0605168eb0e8bf79952b256dbefffd"
 dependencies = [
  "fallible-iterator",
  "stable_deref_trait",
@@ -1868,7 +1905,7 @@ dependencies = [
  "futures-core",
  "futures-sink",
  "futures-util",
- "http",
+ "http 0.2.12",
  "indexmap 2.2.6",
  "slab",
  "tokio",
@@ -1974,13 +2011,47 @@ dependencies = [
 ]
 
 [[package]]
+name = "http"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "21b9ddb458710bc376481b842f5da65cdf31522de232c1ca8146abce2a358258"
+dependencies = [
+ "bytes",
+ "fnv",
+ "itoa",
+]
+
+[[package]]
 name = "http-body"
 version = "0.4.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7ceab25649e9960c0311ea418d17bee82c0dcec1bd053b5f9a66e265a693bed2"
 dependencies = [
  "bytes",
- "http",
+ "http 0.2.12",
+ "pin-project-lite",
+]
+
+[[package]]
+name = "http-body"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1cac85db508abc24a2e48553ba12a996e87244a0395ce011e62b37158745d643"
+dependencies = [
+ "bytes",
+ "http 1.1.0",
+]
+
+[[package]]
+name = "http-body-util"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0475f8b2ac86659c21b64320d5d653f9efe42acd2a4e560073ec61a155a34f1d"
+dependencies = [
+ "bytes",
+ "futures-core",
+ "http 1.1.0",
+ "http-body 1.0.0",
  "pin-project-lite",
 ]
 
@@ -2013,8 +2084,8 @@ dependencies = [
  "futures-core",
  "futures-util",
  "h2",
- "http",
- "http-body",
+ "http 0.2.12",
+ "http-body 0.4.6",
  "httparse",
  "httpdate",
  "itoa",
@@ -2027,17 +2098,73 @@ dependencies = [
 ]
 
 [[package]]
+name = "hyper"
+version = "1.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fe575dd17d0862a9a33781c8c4696a55c320909004a67a00fb286ba8b1bc496d"
+dependencies = [
+ "bytes",
+ "futures-channel",
+ "futures-util",
+ "http 1.1.0",
+ "http-body 1.0.0",
+ "httparse",
+ "itoa",
+ "pin-project-lite",
+ "smallvec",
+ "tokio",
+ "want",
+]
+
+[[package]]
 name = "hyper-rustls"
 version = "0.24.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ec3efd23720e2049821a693cbc7e65ea87c72f1c58ff2f9522ff332b1491e590"
 dependencies = [
  "futures-util",
- "http",
- "hyper",
- "rustls",
+ "http 0.2.12",
+ "hyper 0.14.28",
+ "rustls 0.21.10",
  "tokio",
- "tokio-rustls",
+ "tokio-rustls 0.24.1",
+]
+
+[[package]]
+name = "hyper-rustls"
+version = "0.26.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a0bea761b46ae2b24eb4aef630d8d1c398157b6fc29e6350ecf090a0b70c952c"
+dependencies = [
+ "futures-util",
+ "http 1.1.0",
+ "hyper 1.3.1",
+ "hyper-util",
+ "rustls 0.22.4",
+ "rustls-pki-types",
+ "tokio",
+ "tokio-rustls 0.25.0",
+ "tower-service",
+]
+
+[[package]]
+name = "hyper-util"
+version = "0.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ca38ef113da30126bbff9cd1705f9273e15d45498615d138b0c20279ac7a76aa"
+dependencies = [
+ "bytes",
+ "futures-channel",
+ "futures-util",
+ "http 1.1.0",
+ "http-body 1.0.0",
+ "hyper 1.3.1",
+ "pin-project-lite",
+ "socket2",
+ "tokio",
+ "tower",
+ "tower-service",
+ "tracing",
 ]
 
 [[package]]
@@ -2383,18 +2510,18 @@ checksum = "523dc4f511e55ab87b694dc30d0f820d60906ef06413f93d4d7a1385599cc149"
 
 [[package]]
 name = "memmap2"
-version = "0.5.10"
+version = "0.9.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "83faa42c0a078c393f6b29d5db232d8be22776a891f8f56e5284faee4a20b327"
+checksum = "fe751422e4a8caa417e13c3ea66452215d7d63e19e604f4980461212f3ae1322"
 dependencies = [
  "libc",
 ]
 
 [[package]]
 name = "metal"
-version = "0.27.0"
+version = "0.28.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c43f73953f8cbe511f021b58f18c3ce1c3d1ae13fe953293e13345bf83217f25"
+checksum = "5637e166ea14be6063a3f8ba5ccb9a4159df7d8f6d61c02fc3d480b1f90dcfcb"
 dependencies = [
  "bitflags 2.5.0",
  "block",
@@ -2430,12 +2557,6 @@ dependencies = [
  "wasi",
  "windows-sys 0.48.0",
 ]
-
-[[package]]
-name = "multimap"
-version = "0.8.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e5ce46fe64a9d73be07dcbe690a38ce1b293be448fd8ce1e6c1b8062c9f72c6a"
 
 [[package]]
 name = "ndarray"
@@ -2507,17 +2628,6 @@ name = "num-conv"
 version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "51d515d32fb182ee37cda2ccdcb92950d6a3c2893aa280e540671c2cd0f3b1d9"
-
-[[package]]
-name = "num-derive"
-version = "0.4.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ed3955f1a9c7c0c15e092f9c887db08b1fc683305fdf6eb6684f22555355e202"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn 2.0.55",
-]
 
 [[package]]
 name = "num-integer"
@@ -2608,16 +2718,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "915b1b472bc21c53464d6c8461c9d3af805ba1ef837e1cac254428f4a77177b1"
 dependencies = [
  "malloc_buf",
- "objc_exception",
-]
-
-[[package]]
-name = "objc_exception"
-version = "0.1.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ad970fb455818ad6cba4c122ad012fae53ae8b4795f86378bce65e4f6bab2ca4"
-dependencies = [
- "cc",
 ]
 
 [[package]]
@@ -2625,6 +2725,15 @@ name = "object"
 version = "0.32.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a6a622008b6e321afc04970976f62ee297fdbaa6f95318ca343e3eebb9648441"
+dependencies = [
+ "memchr",
+]
+
+[[package]]
+name = "object"
+version = "0.35.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b8ec7ab813848ba4522158d5517a6093db1ded27575b070f4177b8d12b41db5e"
 dependencies = [
  "flate2",
  "memchr",
@@ -2747,16 +2856,6 @@ dependencies = [
  "memchr",
  "thiserror",
  "ucd-trie",
-]
-
-[[package]]
-name = "petgraph"
-version = "0.6.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e1d3afd2628e69da2be385eb6f2fd57c8ac7977ceeff6dc166ff1657b0e386a9"
-dependencies = [
- "fixedbitset",
- "indexmap 2.2.6",
 ]
 
 [[package]]
@@ -2969,28 +3068,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "prost-build"
-version = "0.12.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c55e02e35260070b6f716a2423c2ff1c3bb1642ddca6f99e1f26d06268a0e2d2"
-dependencies = [
- "bytes",
- "heck 0.4.1",
- "itertools 0.11.0",
- "log",
- "multimap",
- "once_cell",
- "petgraph",
- "prettyplease",
- "prost",
- "prost-types",
- "regex",
- "syn 2.0.55",
- "tempfile",
- "which",
-]
-
-[[package]]
 name = "prost-derive"
 version = "0.12.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3001,24 +3078,6 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 2.0.55",
-]
-
-[[package]]
-name = "prost-types"
-version = "0.12.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "193898f59edcf43c26227dcd4c8427f00d99d61e95dcde58dabd49fa291d470e"
-dependencies = [
- "prost",
-]
-
-[[package]]
-name = "protobuf-src"
-version = "1.1.0+21.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c7ac8852baeb3cc6fb83b93646fb93c0ffe5d14bf138c945ceb4b9948ee0e3c1"
-dependencies = [
- "autotools",
 ]
 
 [[package]]
@@ -3174,10 +3233,10 @@ dependencies = [
  "futures-core",
  "futures-util",
  "h2",
- "http",
- "http-body",
- "hyper",
- "hyper-rustls",
+ "http 0.2.12",
+ "http-body 0.4.6",
+ "hyper 0.14.28",
+ "hyper-rustls 0.24.2",
  "ipnet",
  "js-sys",
  "log",
@@ -3185,22 +3244,64 @@ dependencies = [
  "once_cell",
  "percent-encoding",
  "pin-project-lite",
- "rustls",
- "rustls-pemfile",
+ "rustls 0.21.10",
+ "rustls-pemfile 1.0.4",
  "serde",
  "serde_json",
  "serde_urlencoded",
  "sync_wrapper",
  "system-configuration",
  "tokio",
- "tokio-rustls",
+ "tokio-rustls 0.24.1",
  "tower-service",
  "url",
  "wasm-bindgen",
  "wasm-bindgen-futures",
  "web-sys",
- "webpki-roots",
- "winreg",
+ "webpki-roots 0.25.4",
+ "winreg 0.50.0",
+]
+
+[[package]]
+name = "reqwest"
+version = "0.12.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "566cafdd92868e0939d3fb961bd0dc25fcfaaed179291093b3d43e6b3150ea10"
+dependencies = [
+ "base64 0.22.1",
+ "bytes",
+ "futures-channel",
+ "futures-core",
+ "futures-util",
+ "http 1.1.0",
+ "http-body 1.0.0",
+ "http-body-util",
+ "hyper 1.3.1",
+ "hyper-rustls 0.26.0",
+ "hyper-util",
+ "ipnet",
+ "js-sys",
+ "log",
+ "mime",
+ "once_cell",
+ "percent-encoding",
+ "pin-project-lite",
+ "rustls 0.22.4",
+ "rustls-pemfile 2.1.2",
+ "rustls-pki-types",
+ "serde",
+ "serde_json",
+ "serde_urlencoded",
+ "sync_wrapper",
+ "tokio",
+ "tokio-rustls 0.25.0",
+ "tower-service",
+ "url",
+ "wasm-bindgen",
+ "wasm-bindgen-futures",
+ "web-sys",
+ "webpki-roots 0.26.1",
+ "winreg 0.52.0",
 ]
 
 [[package]]
@@ -3313,9 +3414,9 @@ dependencies = [
 
 [[package]]
 name = "risc0-binfmt"
-version = "1.0.0-rc.3"
+version = "1.0.0-rc.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e0bf2b3120d663dc0f1295c26c40c0bb22774a0bea3409adaa6cf0de5cadf518"
+checksum = "174598af56aad42537c50d05c226cc7e346f8fda5f1fbe39ded52836fed3753e"
 dependencies = [
  "anyhow",
  "elf",
@@ -3327,12 +3428,11 @@ dependencies = [
 
 [[package]]
 name = "risc0-build"
-version = "1.0.0-rc.3"
+version = "1.0.0-rc.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e5f31ea763c2c1f98da3dd4f56edec6a55f862196fc2849550b57fcb3bd98f89"
+checksum = "8c59874be9fa3448bbaea00f8232becaee4d13272c89dd82ad6b3e50d6814c48"
 dependencies = [
  "anyhow",
- "cargo-platform",
  "cargo_metadata",
  "dirs",
  "docker-generate",
@@ -3346,22 +3446,25 @@ dependencies = [
 
 [[package]]
 name = "risc0-build-kernel"
-version = "1.0.0-rc.3"
+version = "1.0.0-rc.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fb02495148768f64fe6f5317409c3e12e424451eb42a4862066157a6553e27f8"
+checksum = "f7cadc546032a4ff68e0f4a2305c7cc12ae2c75940e7aa7dda43e26cc07279b7"
 dependencies = [
  "cc",
  "directories",
+ "glob",
  "hex",
+ "rayon",
  "sha2",
  "tempfile",
+ "which",
 ]
 
 [[package]]
 name = "risc0-circuit-recursion"
-version = "1.0.0-rc.3"
+version = "1.0.0-rc.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "45ac9b0ab1b097a76e11c1bd265e145ab8e0f4d54e37b94f596fabf92a1ee289"
+checksum = "f4bf5ca899bb3650a9eed60450795a749925b5eb09a29e8a7fb8ef3122034ac6"
 dependencies = [
  "anyhow",
  "bytemuck",
@@ -3373,6 +3476,7 @@ dependencies = [
  "rayon",
  "risc0-circuit-recursion-sys",
  "risc0-core",
+ "risc0-sys",
  "risc0-zkp",
  "sha2",
  "tracing",
@@ -3381,20 +3485,21 @@ dependencies = [
 
 [[package]]
 name = "risc0-circuit-recursion-sys"
-version = "1.0.0-rc.3"
+version = "1.0.0-rc.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "204878eeddb520d4685a1b67c9a7a0d19acb15e43d778156617fe99fc3ffd11e"
+checksum = "8d330a6b96351e6226fa4544aced2e78e851b6339c2fd58878835b5e3da6f53c"
 dependencies = [
  "glob",
  "risc0-build-kernel",
  "risc0-core",
+ "risc0-sys",
 ]
 
 [[package]]
 name = "risc0-circuit-rv32im"
-version = "1.0.0-rc.3"
+version = "1.0.0-rc.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "17da0fb133b11710cc65e96e711765ff9962611ce21fc0d325bb3fb9fd5e39ab"
+checksum = "ec21b15f8dcccf0826e0ea5a6efbb572b1c324d24c7c011d5b1ebf7201b47dbb"
 dependencies = [
  "anyhow",
  "bytemuck",
@@ -3410,6 +3515,7 @@ dependencies = [
  "risc0-binfmt",
  "risc0-circuit-rv32im-sys",
  "risc0-core",
+ "risc0-sys",
  "risc0-zkp",
  "risc0-zkvm-platform",
  "serde",
@@ -3419,20 +3525,21 @@ dependencies = [
 
 [[package]]
 name = "risc0-circuit-rv32im-sys"
-version = "1.0.0-rc.3"
+version = "1.0.0-rc.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "50698c77a4e312e32db406e0397a7d65ae61a2658dad76cc5ddeab77ce227ace"
+checksum = "0b865ceee278c522be3fba3ca13144a4b150ec29d633e094fb5d90315226d2bc"
 dependencies = [
  "glob",
  "risc0-build-kernel",
  "risc0-core",
+ "risc0-sys",
 ]
 
 [[package]]
 name = "risc0-core"
-version = "1.0.0-rc.3"
+version = "1.0.0-rc.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "23a015abc51d21f6a2f05968597e86492618722f5a4db961225f7fb674b45812"
+checksum = "2e69e8ea72d38052b349e1598cb229d3f965bac6b1134b00f05ef090c792a42b"
 dependencies = [
  "bytemuck",
  "rand_core",
@@ -3440,19 +3547,20 @@ dependencies = [
 
 [[package]]
 name = "risc0-groth16"
-version = "1.0.0-rc.3"
+version = "1.0.0-rc.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b61c1e15b5d586f7c987d9ca3a1dfb888855c7b8ad0ffb097f8bfa89a01773ad"
+checksum = "313483931948778b91ea105c115ccc833f4b058649fb13f1b36f99325e04f0e8"
 dependencies = [
  "anyhow",
  "ark-bn254",
+ "ark-ec",
  "ark-groth16",
  "ark-serialize 0.4.2",
  "bytemuck",
  "hex",
  "num-bigint 0.4.4",
- "num-derive",
  "num-traits",
+ "risc0-binfmt",
  "risc0-core",
  "risc0-zkp",
  "serde",
@@ -3463,9 +3571,9 @@ dependencies = [
 
 [[package]]
 name = "risc0-sys"
-version = "1.0.0-rc.3"
+version = "1.0.0-rc.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9ff5482e6da970553377ce4d9f60ab7b538ca922f99bfea53a7cb39f2d77f03d"
+checksum = "6f272915a2de8fbb463c687985f0bc8440f6541d47211204d3b38a1a9e19a8a7"
 dependencies = [
  "cc",
  "risc0-build-kernel",
@@ -3473,13 +3581,14 @@ dependencies = [
 
 [[package]]
 name = "risc0-zkp"
-version = "1.0.0-rc.3"
+version = "1.0.0-rc.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "44a10836da64aabb816ac7d812718cb461b6f43e7c58847e5b36a2a9a60a8132"
+checksum = "488a3d73143affc2ccae0e2619790c6ab44f794591923b5f0e7df1ede09c8509"
 dependencies = [
  "anyhow",
  "blake2",
  "bytemuck",
+ "cfg-if",
  "digest 0.10.7",
  "ff",
  "hex",
@@ -3501,14 +3610,14 @@ dependencies = [
 
 [[package]]
 name = "risc0-zkvm"
-version = "1.0.0-rc.3"
+version = "1.0.0-rc.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a6f4f516803fa363f7ce877f61716dfe0dcd293317e54fb76ed3f71419bcb297"
+checksum = "749eaa5169256cabc910e2143d2fcaf25c465dc9e348fd7e01b696f02d19d957"
 dependencies = [
- "addr2line",
+ "addr2line 0.22.0",
  "anyhow",
  "bincode",
- "bonsai-sdk 0.8.0-rc.1",
+ "bonsai-sdk 0.8.0-rc.2",
  "bytemuck",
  "bytes",
  "cfg-if",
@@ -3518,8 +3627,6 @@ dependencies = [
  "lazy-regex",
  "nvtx",
  "prost",
- "prost-build",
- "protobuf-src",
  "rand",
  "rayon",
  "risc0-binfmt",
@@ -3541,9 +3648,9 @@ dependencies = [
 
 [[package]]
 name = "risc0-zkvm-platform"
-version = "1.0.0-rc.3"
+version = "1.0.0-rc.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b87b12fd67bdd81e69506b571ab55eb8f52b2d8a22c8a4aeb249ceea84ade971"
+checksum = "20e006ec91eecbff9c0849a9028c5558495292d333d3a0841e35db0f77baf3fb"
 dependencies = [
  "bytemuck",
  "getrandom",
@@ -3698,8 +3805,22 @@ checksum = "f9d5a6813c0759e4609cd494e8e725babae6a2ca7b62a5536a13daaec6fcb7ba"
 dependencies = [
  "log",
  "ring 0.17.8",
- "rustls-webpki",
+ "rustls-webpki 0.101.7",
  "sct",
+]
+
+[[package]]
+name = "rustls"
+version = "0.22.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bf4ef73721ac7bcd79b2b315da7779d8fc09718c6b3d2d1b2d94850eb8c18432"
+dependencies = [
+ "log",
+ "ring 0.17.8",
+ "rustls-pki-types",
+ "rustls-webpki 0.102.4",
+ "subtle",
+ "zeroize",
 ]
 
 [[package]]
@@ -3712,12 +3833,39 @@ dependencies = [
 ]
 
 [[package]]
+name = "rustls-pemfile"
+version = "2.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "29993a25686778eb88d4189742cd713c9bce943bc54251a33509dc63cbacf73d"
+dependencies = [
+ "base64 0.22.1",
+ "rustls-pki-types",
+]
+
+[[package]]
+name = "rustls-pki-types"
+version = "1.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "976295e77ce332211c0d24d92c0e83e50f5c5f046d11082cea19f3df13a3562d"
+
+[[package]]
 name = "rustls-webpki"
 version = "0.101.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8b6275d1ee7a1cd780b64aca7726599a1dbc893b1e64144529e55c3c2f745765"
 dependencies = [
  "ring 0.17.8",
+ "untrusted 0.9.0",
+]
+
+[[package]]
+name = "rustls-webpki"
+version = "0.102.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ff448f7e92e913c4b7d4c6d8e4540a1724b319b4152b8aef6d4cf8339712b33e"
+dependencies = [
+ "ring 0.17.8",
+ "rustls-pki-types",
  "untrusted 0.9.0",
 ]
 
@@ -3741,9 +3889,9 @@ dependencies = [
 
 [[package]]
 name = "ruzstd"
-version = "0.5.0"
+version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "58c4eb8a81997cf040a091d1f7e1938aeab6749d3a0dfa73af43cdc32393483d"
+checksum = "5174a470eeb535a721ae9fdd6e291c2411a906b96592182d05217591d5c5cf7b"
 dependencies = [
  "byteorder",
  "derive_more",
@@ -4349,7 +4497,18 @@ version = "0.24.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c28327cf380ac148141087fbfb9de9d7bd4e84ab5d2c28fbc911d753de8a7081"
 dependencies = [
- "rustls",
+ "rustls 0.21.10",
+ "tokio",
+]
+
+[[package]]
+name = "tokio-rustls"
+version = "0.25.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "775e0c0f0adb3a2f22a00c4745d728b479985fc15ee7ca6a2608388c5569860f"
+dependencies = [
+ "rustls 0.22.4",
+ "rustls-pki-types",
  "tokio",
 ]
 
@@ -4361,11 +4520,11 @@ checksum = "212d5dcb2a1ce06d81107c3d0ffa3121fe974b73f068c8282cb1c32328113b6c"
 dependencies = [
  "futures-util",
  "log",
- "rustls",
+ "rustls 0.21.10",
  "tokio",
- "tokio-rustls",
+ "tokio-rustls 0.24.1",
  "tungstenite",
- "webpki-roots",
+ "webpki-roots 0.25.4",
 ]
 
 [[package]]
@@ -4450,6 +4609,28 @@ dependencies = [
 ]
 
 [[package]]
+name = "tower"
+version = "0.4.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b8fa9be0de6cf49e536ce1851f987bd21a43b771b09473c3549a6c853db37c1c"
+dependencies = [
+ "futures-core",
+ "futures-util",
+ "pin-project",
+ "pin-project-lite",
+ "tokio",
+ "tower-layer",
+ "tower-service",
+ "tracing",
+]
+
+[[package]]
+name = "tower-layer"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c20c8dbed6283a09604c3e69b4b7eeb54e298b8a600d4d5ecb5ad39de609f1d0"
+
+[[package]]
 name = "tower-service"
 version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4522,11 +4703,11 @@ dependencies = [
  "byteorder",
  "bytes",
  "data-encoding",
- "http",
+ "http 0.2.12",
  "httparse",
  "log",
  "rand",
- "rustls",
+ "rustls 0.21.10",
  "sha1",
  "thiserror",
  "url",
@@ -4788,15 +4969,24 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5f20c57d8d7db6d3b86154206ae5d8fba62dd39573114de97c2cb0578251f8e1"
 
 [[package]]
-name = "which"
-version = "4.4.2"
+name = "webpki-roots"
+version = "0.26.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "87ba24419a2078cd2b0f2ede2691b6c66d8e47836da3b6db8265ebad47afbfc7"
+checksum = "b3de34ae270483955a94f4b21bdaaeb83d508bb84a01435f393818edb0012009"
+dependencies = [
+ "rustls-pki-types",
+]
+
+[[package]]
+name = "which"
+version = "6.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8211e4f58a2b2805adfbefbc07bab82958fc91e3836339b1ab7ae32465dce0d7"
 dependencies = [
  "either",
  "home",
- "once_cell",
  "rustix",
+ "winsafe",
 ]
 
 [[package]]
@@ -5000,6 +5190,22 @@ dependencies = [
 ]
 
 [[package]]
+name = "winreg"
+version = "0.52.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a277a57398d4bfa075df44f501a17cfdf8542d224f0d36095a2adc7aee4ef0a5"
+dependencies = [
+ "cfg-if",
+ "windows-sys 0.48.0",
+]
+
+[[package]]
+name = "winsafe"
+version = "0.0.19"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d135d17ab770252ad95e9a872d365cf3090e3be864a34ab46f48555993efc904"
+
+[[package]]
 name = "ws_stream_wasm"
 version = "0.7.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5179,12 +5385,15 @@ dependencies = [
 
 [[package]]
 name = "zip"
-version = "0.6.6"
+version = "1.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "760394e246e4c28189f19d488c058bf16f564016aefac5d32bb1f3b51d5e9261"
+checksum = "f1f4a27345eb6f7aa7bd015ba7eb4175fa4e1b462a29874b779e0bbcf96c6ac7"
 dependencies = [
- "byteorder",
+ "arbitrary",
  "crc32fast",
  "crossbeam-utils",
+ "displaydoc",
  "flate2",
+ "indexmap 2.2.6",
+ "thiserror",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,8 +19,8 @@ opt-level = 3
 [workspace.dependencies]
 bonsai-sdk = { version = "0.6.0", features = ["async"] }
 hashbrown = { version = "0.14.3", features = ["inline-more"] }
-risc0-build = { version = "1.0.0-rc.3" }
-risc0-zkvm = { version = "1.0.0-rc.3", default-features = false }
+risc0-build = { version = "1.0.0-rc.5" }
+risc0-zkvm = { version = "1.0.0-rc.5", default-features = false }
 revm-primitives = { version = "2.0", default_features = false }
 revm = { version = "5.0", default-features = false, features = [
     "std",

--- a/guests/eth-block/Cargo.lock
+++ b/guests/eth-block/Cargo.lock
@@ -1690,17 +1690,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "51d515d32fb182ee37cda2ccdcb92950d6a3c2893aa280e540671c2cd0f3b1d9"
 
 [[package]]
-name = "num-derive"
-version = "0.4.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ed3955f1a9c7c0c15e092f9c887db08b1fc683305fdf6eb6684f22555355e202"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn 2.0.48",
-]
-
-[[package]]
 name = "num-integer"
 version = "0.1.46"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2301,9 +2290,9 @@ dependencies = [
 
 [[package]]
 name = "risc0-binfmt"
-version = "1.0.0-rc.3"
+version = "1.0.0-rc.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e0bf2b3120d663dc0f1295c26c40c0bb22774a0bea3409adaa6cf0de5cadf518"
+checksum = "174598af56aad42537c50d05c226cc7e346f8fda5f1fbe39ded52836fed3753e"
 dependencies = [
  "anyhow",
  "elf",
@@ -2315,9 +2304,9 @@ dependencies = [
 
 [[package]]
 name = "risc0-circuit-recursion"
-version = "1.0.0-rc.3"
+version = "1.0.0-rc.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "45ac9b0ab1b097a76e11c1bd265e145ab8e0f4d54e37b94f596fabf92a1ee289"
+checksum = "f4bf5ca899bb3650a9eed60450795a749925b5eb09a29e8a7fb8ef3122034ac6"
 dependencies = [
  "anyhow",
  "bytemuck",
@@ -2329,9 +2318,9 @@ dependencies = [
 
 [[package]]
 name = "risc0-circuit-rv32im"
-version = "1.0.0-rc.3"
+version = "1.0.0-rc.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "17da0fb133b11710cc65e96e711765ff9962611ce21fc0d325bb3fb9fd5e39ab"
+checksum = "ec21b15f8dcccf0826e0ea5a6efbb572b1c324d24c7c011d5b1ebf7201b47dbb"
 dependencies = [
  "anyhow",
  "risc0-binfmt",
@@ -2344,9 +2333,9 @@ dependencies = [
 
 [[package]]
 name = "risc0-core"
-version = "1.0.0-rc.3"
+version = "1.0.0-rc.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "23a015abc51d21f6a2f05968597e86492618722f5a4db961225f7fb674b45812"
+checksum = "2e69e8ea72d38052b349e1598cb229d3f965bac6b1134b00f05ef090c792a42b"
 dependencies = [
  "bytemuck",
  "rand_core",
@@ -2354,31 +2343,34 @@ dependencies = [
 
 [[package]]
 name = "risc0-groth16"
-version = "1.0.0-rc.3"
+version = "1.0.0-rc.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b61c1e15b5d586f7c987d9ca3a1dfb888855c7b8ad0ffb097f8bfa89a01773ad"
+checksum = "313483931948778b91ea105c115ccc833f4b058649fb13f1b36f99325e04f0e8"
 dependencies = [
  "anyhow",
  "ark-bn254",
+ "ark-ec",
  "ark-groth16",
  "ark-serialize 0.4.2",
+ "bytemuck",
  "hex",
  "num-bigint",
- "num-derive",
  "num-traits",
+ "risc0-binfmt",
  "risc0-zkp",
  "serde",
 ]
 
 [[package]]
 name = "risc0-zkp"
-version = "1.0.0-rc.3"
+version = "1.0.0-rc.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "44a10836da64aabb816ac7d812718cb461b6f43e7c58847e5b36a2a9a60a8132"
+checksum = "488a3d73143affc2ccae0e2619790c6ab44f794591923b5f0e7df1ede09c8509"
 dependencies = [
  "anyhow",
  "blake2",
  "bytemuck",
+ "cfg-if",
  "digest 0.10.7",
  "hex",
  "paste",
@@ -2392,9 +2384,9 @@ dependencies = [
 
 [[package]]
 name = "risc0-zkvm"
-version = "1.0.0-rc.3"
+version = "1.0.0-rc.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a6f4f516803fa363f7ce877f61716dfe0dcd293317e54fb76ed3f71419bcb297"
+checksum = "749eaa5169256cabc910e2143d2fcaf25c465dc9e348fd7e01b696f02d19d957"
 dependencies = [
  "anyhow",
  "bytemuck",
@@ -2417,9 +2409,9 @@ dependencies = [
 
 [[package]]
 name = "risc0-zkvm-platform"
-version = "1.0.0-rc.3"
+version = "1.0.0-rc.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b87b12fd67bdd81e69506b571ab55eb8f52b2d8a22c8a4aeb249ceea84ade971"
+checksum = "20e006ec91eecbff9c0849a9028c5558495292d333d3a0841e35db0f77baf3fb"
 dependencies = [
  "bytemuck",
  "getrandom",

--- a/guests/eth-block/Cargo.toml
+++ b/guests/eth-block/Cargo.toml
@@ -6,7 +6,7 @@ edition = "2021"
 [workspace]
 
 [dependencies]
-risc0-zkvm = { version = "1.0.0-rc.3", default-features = false, features = ['std'] }
+risc0-zkvm = { version = "1.0.0-rc.5", default-features = false, features = ['std'] }
 zeth-lib = { path = "../../lib", default-features = false }
 
 [patch.crates-io]

--- a/guests/op-block/Cargo.lock
+++ b/guests/op-block/Cargo.lock
@@ -1682,17 +1682,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "51d515d32fb182ee37cda2ccdcb92950d6a3c2893aa280e540671c2cd0f3b1d9"
 
 [[package]]
-name = "num-derive"
-version = "0.4.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ed3955f1a9c7c0c15e092f9c887db08b1fc683305fdf6eb6684f22555355e202"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn 2.0.48",
-]
-
-[[package]]
 name = "num-integer"
 version = "0.1.46"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2301,9 +2290,9 @@ dependencies = [
 
 [[package]]
 name = "risc0-binfmt"
-version = "1.0.0-rc.3"
+version = "1.0.0-rc.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e0bf2b3120d663dc0f1295c26c40c0bb22774a0bea3409adaa6cf0de5cadf518"
+checksum = "174598af56aad42537c50d05c226cc7e346f8fda5f1fbe39ded52836fed3753e"
 dependencies = [
  "anyhow",
  "elf",
@@ -2315,9 +2304,9 @@ dependencies = [
 
 [[package]]
 name = "risc0-circuit-recursion"
-version = "1.0.0-rc.3"
+version = "1.0.0-rc.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "45ac9b0ab1b097a76e11c1bd265e145ab8e0f4d54e37b94f596fabf92a1ee289"
+checksum = "f4bf5ca899bb3650a9eed60450795a749925b5eb09a29e8a7fb8ef3122034ac6"
 dependencies = [
  "anyhow",
  "bytemuck",
@@ -2329,9 +2318,9 @@ dependencies = [
 
 [[package]]
 name = "risc0-circuit-rv32im"
-version = "1.0.0-rc.3"
+version = "1.0.0-rc.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "17da0fb133b11710cc65e96e711765ff9962611ce21fc0d325bb3fb9fd5e39ab"
+checksum = "ec21b15f8dcccf0826e0ea5a6efbb572b1c324d24c7c011d5b1ebf7201b47dbb"
 dependencies = [
  "anyhow",
  "risc0-binfmt",
@@ -2344,9 +2333,9 @@ dependencies = [
 
 [[package]]
 name = "risc0-core"
-version = "1.0.0-rc.3"
+version = "1.0.0-rc.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "23a015abc51d21f6a2f05968597e86492618722f5a4db961225f7fb674b45812"
+checksum = "2e69e8ea72d38052b349e1598cb229d3f965bac6b1134b00f05ef090c792a42b"
 dependencies = [
  "bytemuck",
  "rand_core",
@@ -2354,31 +2343,34 @@ dependencies = [
 
 [[package]]
 name = "risc0-groth16"
-version = "1.0.0-rc.3"
+version = "1.0.0-rc.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b61c1e15b5d586f7c987d9ca3a1dfb888855c7b8ad0ffb097f8bfa89a01773ad"
+checksum = "313483931948778b91ea105c115ccc833f4b058649fb13f1b36f99325e04f0e8"
 dependencies = [
  "anyhow",
  "ark-bn254",
+ "ark-ec",
  "ark-groth16",
  "ark-serialize 0.4.2",
+ "bytemuck",
  "hex",
  "num-bigint",
- "num-derive",
  "num-traits",
+ "risc0-binfmt",
  "risc0-zkp",
  "serde",
 ]
 
 [[package]]
 name = "risc0-zkp"
-version = "1.0.0-rc.3"
+version = "1.0.0-rc.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "44a10836da64aabb816ac7d812718cb461b6f43e7c58847e5b36a2a9a60a8132"
+checksum = "488a3d73143affc2ccae0e2619790c6ab44f794591923b5f0e7df1ede09c8509"
 dependencies = [
  "anyhow",
  "blake2",
  "bytemuck",
+ "cfg-if",
  "digest 0.10.7",
  "hex",
  "paste",
@@ -2392,9 +2384,9 @@ dependencies = [
 
 [[package]]
 name = "risc0-zkvm"
-version = "1.0.0-rc.3"
+version = "1.0.0-rc.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a6f4f516803fa363f7ce877f61716dfe0dcd293317e54fb76ed3f71419bcb297"
+checksum = "749eaa5169256cabc910e2143d2fcaf25c465dc9e348fd7e01b696f02d19d957"
 dependencies = [
  "anyhow",
  "bytemuck",
@@ -2417,9 +2409,9 @@ dependencies = [
 
 [[package]]
 name = "risc0-zkvm-platform"
-version = "1.0.0-rc.3"
+version = "1.0.0-rc.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b87b12fd67bdd81e69506b571ab55eb8f52b2d8a22c8a4aeb249ceea84ade971"
+checksum = "20e006ec91eecbff9c0849a9028c5558495292d333d3a0841e35db0f77baf3fb"
 dependencies = [
  "bytemuck",
  "getrandom",

--- a/guests/op-block/Cargo.toml
+++ b/guests/op-block/Cargo.toml
@@ -6,7 +6,7 @@ edition = "2021"
 [workspace]
 
 [dependencies]
-risc0-zkvm = { version = "1.0.0-rc.3", default-features = false, features = ['std'] }
+risc0-zkvm = { version = "1.0.0-rc.5", default-features = false, features = ['std'] }
 zeth-lib = { path = "../../lib", default-features = false }
 
 [patch.crates-io]

--- a/guests/op-compose/Cargo.lock
+++ b/guests/op-compose/Cargo.lock
@@ -1682,17 +1682,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "51d515d32fb182ee37cda2ccdcb92950d6a3c2893aa280e540671c2cd0f3b1d9"
 
 [[package]]
-name = "num-derive"
-version = "0.4.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ed3955f1a9c7c0c15e092f9c887db08b1fc683305fdf6eb6684f22555355e202"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn 2.0.48",
-]
-
-[[package]]
 name = "num-integer"
 version = "0.1.46"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2301,9 +2290,9 @@ dependencies = [
 
 [[package]]
 name = "risc0-binfmt"
-version = "1.0.0-rc.3"
+version = "1.0.0-rc.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e0bf2b3120d663dc0f1295c26c40c0bb22774a0bea3409adaa6cf0de5cadf518"
+checksum = "174598af56aad42537c50d05c226cc7e346f8fda5f1fbe39ded52836fed3753e"
 dependencies = [
  "anyhow",
  "elf",
@@ -2315,9 +2304,9 @@ dependencies = [
 
 [[package]]
 name = "risc0-circuit-recursion"
-version = "1.0.0-rc.3"
+version = "1.0.0-rc.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "45ac9b0ab1b097a76e11c1bd265e145ab8e0f4d54e37b94f596fabf92a1ee289"
+checksum = "f4bf5ca899bb3650a9eed60450795a749925b5eb09a29e8a7fb8ef3122034ac6"
 dependencies = [
  "anyhow",
  "bytemuck",
@@ -2329,9 +2318,9 @@ dependencies = [
 
 [[package]]
 name = "risc0-circuit-rv32im"
-version = "1.0.0-rc.3"
+version = "1.0.0-rc.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "17da0fb133b11710cc65e96e711765ff9962611ce21fc0d325bb3fb9fd5e39ab"
+checksum = "ec21b15f8dcccf0826e0ea5a6efbb572b1c324d24c7c011d5b1ebf7201b47dbb"
 dependencies = [
  "anyhow",
  "risc0-binfmt",
@@ -2344,9 +2333,9 @@ dependencies = [
 
 [[package]]
 name = "risc0-core"
-version = "1.0.0-rc.3"
+version = "1.0.0-rc.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "23a015abc51d21f6a2f05968597e86492618722f5a4db961225f7fb674b45812"
+checksum = "2e69e8ea72d38052b349e1598cb229d3f965bac6b1134b00f05ef090c792a42b"
 dependencies = [
  "bytemuck",
  "rand_core",
@@ -2354,31 +2343,34 @@ dependencies = [
 
 [[package]]
 name = "risc0-groth16"
-version = "1.0.0-rc.3"
+version = "1.0.0-rc.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b61c1e15b5d586f7c987d9ca3a1dfb888855c7b8ad0ffb097f8bfa89a01773ad"
+checksum = "313483931948778b91ea105c115ccc833f4b058649fb13f1b36f99325e04f0e8"
 dependencies = [
  "anyhow",
  "ark-bn254",
+ "ark-ec",
  "ark-groth16",
  "ark-serialize 0.4.2",
+ "bytemuck",
  "hex",
  "num-bigint",
- "num-derive",
  "num-traits",
+ "risc0-binfmt",
  "risc0-zkp",
  "serde",
 ]
 
 [[package]]
 name = "risc0-zkp"
-version = "1.0.0-rc.3"
+version = "1.0.0-rc.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "44a10836da64aabb816ac7d812718cb461b6f43e7c58847e5b36a2a9a60a8132"
+checksum = "488a3d73143affc2ccae0e2619790c6ab44f794591923b5f0e7df1ede09c8509"
 dependencies = [
  "anyhow",
  "blake2",
  "bytemuck",
+ "cfg-if",
  "digest 0.10.7",
  "hex",
  "paste",
@@ -2392,9 +2384,9 @@ dependencies = [
 
 [[package]]
 name = "risc0-zkvm"
-version = "1.0.0-rc.3"
+version = "1.0.0-rc.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a6f4f516803fa363f7ce877f61716dfe0dcd293317e54fb76ed3f71419bcb297"
+checksum = "749eaa5169256cabc910e2143d2fcaf25c465dc9e348fd7e01b696f02d19d957"
 dependencies = [
  "anyhow",
  "bytemuck",
@@ -2417,9 +2409,9 @@ dependencies = [
 
 [[package]]
 name = "risc0-zkvm-platform"
-version = "1.0.0-rc.3"
+version = "1.0.0-rc.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b87b12fd67bdd81e69506b571ab55eb8f52b2d8a22c8a4aeb249ceea84ade971"
+checksum = "20e006ec91eecbff9c0849a9028c5558495292d333d3a0841e35db0f77baf3fb"
 dependencies = [
  "bytemuck",
  "getrandom",

--- a/guests/op-compose/Cargo.toml
+++ b/guests/op-compose/Cargo.toml
@@ -6,7 +6,7 @@ edition = "2021"
 [workspace]
 
 [dependencies]
-risc0-zkvm = { version = "1.0.0-rc.3", default-features = false, features = ['std'] }
+risc0-zkvm = { version = "1.0.0-rc.5", default-features = false, features = ['std'] }
 zeth-lib = { path = "../../lib", default-features = false }
 
 [patch.crates-io]

--- a/guests/op-derive/Cargo.lock
+++ b/guests/op-derive/Cargo.lock
@@ -1682,17 +1682,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "51d515d32fb182ee37cda2ccdcb92950d6a3c2893aa280e540671c2cd0f3b1d9"
 
 [[package]]
-name = "num-derive"
-version = "0.4.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ed3955f1a9c7c0c15e092f9c887db08b1fc683305fdf6eb6684f22555355e202"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn 2.0.48",
-]
-
-[[package]]
 name = "num-integer"
 version = "0.1.46"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2301,9 +2290,9 @@ dependencies = [
 
 [[package]]
 name = "risc0-binfmt"
-version = "1.0.0-rc.3"
+version = "1.0.0-rc.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e0bf2b3120d663dc0f1295c26c40c0bb22774a0bea3409adaa6cf0de5cadf518"
+checksum = "174598af56aad42537c50d05c226cc7e346f8fda5f1fbe39ded52836fed3753e"
 dependencies = [
  "anyhow",
  "elf",
@@ -2315,9 +2304,9 @@ dependencies = [
 
 [[package]]
 name = "risc0-circuit-recursion"
-version = "1.0.0-rc.3"
+version = "1.0.0-rc.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "45ac9b0ab1b097a76e11c1bd265e145ab8e0f4d54e37b94f596fabf92a1ee289"
+checksum = "f4bf5ca899bb3650a9eed60450795a749925b5eb09a29e8a7fb8ef3122034ac6"
 dependencies = [
  "anyhow",
  "bytemuck",
@@ -2329,9 +2318,9 @@ dependencies = [
 
 [[package]]
 name = "risc0-circuit-rv32im"
-version = "1.0.0-rc.3"
+version = "1.0.0-rc.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "17da0fb133b11710cc65e96e711765ff9962611ce21fc0d325bb3fb9fd5e39ab"
+checksum = "ec21b15f8dcccf0826e0ea5a6efbb572b1c324d24c7c011d5b1ebf7201b47dbb"
 dependencies = [
  "anyhow",
  "risc0-binfmt",
@@ -2344,9 +2333,9 @@ dependencies = [
 
 [[package]]
 name = "risc0-core"
-version = "1.0.0-rc.3"
+version = "1.0.0-rc.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "23a015abc51d21f6a2f05968597e86492618722f5a4db961225f7fb674b45812"
+checksum = "2e69e8ea72d38052b349e1598cb229d3f965bac6b1134b00f05ef090c792a42b"
 dependencies = [
  "bytemuck",
  "rand_core",
@@ -2354,31 +2343,34 @@ dependencies = [
 
 [[package]]
 name = "risc0-groth16"
-version = "1.0.0-rc.3"
+version = "1.0.0-rc.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b61c1e15b5d586f7c987d9ca3a1dfb888855c7b8ad0ffb097f8bfa89a01773ad"
+checksum = "313483931948778b91ea105c115ccc833f4b058649fb13f1b36f99325e04f0e8"
 dependencies = [
  "anyhow",
  "ark-bn254",
+ "ark-ec",
  "ark-groth16",
  "ark-serialize 0.4.2",
+ "bytemuck",
  "hex",
  "num-bigint",
- "num-derive",
  "num-traits",
+ "risc0-binfmt",
  "risc0-zkp",
  "serde",
 ]
 
 [[package]]
 name = "risc0-zkp"
-version = "1.0.0-rc.3"
+version = "1.0.0-rc.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "44a10836da64aabb816ac7d812718cb461b6f43e7c58847e5b36a2a9a60a8132"
+checksum = "488a3d73143affc2ccae0e2619790c6ab44f794591923b5f0e7df1ede09c8509"
 dependencies = [
  "anyhow",
  "blake2",
  "bytemuck",
+ "cfg-if",
  "digest 0.10.7",
  "hex",
  "paste",
@@ -2392,9 +2384,9 @@ dependencies = [
 
 [[package]]
 name = "risc0-zkvm"
-version = "1.0.0-rc.3"
+version = "1.0.0-rc.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a6f4f516803fa363f7ce877f61716dfe0dcd293317e54fb76ed3f71419bcb297"
+checksum = "749eaa5169256cabc910e2143d2fcaf25c465dc9e348fd7e01b696f02d19d957"
 dependencies = [
  "anyhow",
  "bytemuck",
@@ -2417,9 +2409,9 @@ dependencies = [
 
 [[package]]
 name = "risc0-zkvm-platform"
-version = "1.0.0-rc.3"
+version = "1.0.0-rc.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b87b12fd67bdd81e69506b571ab55eb8f52b2d8a22c8a4aeb249ceea84ade971"
+checksum = "20e006ec91eecbff9c0849a9028c5558495292d333d3a0841e35db0f77baf3fb"
 dependencies = [
  "bytemuck",
  "getrandom",

--- a/guests/op-derive/Cargo.toml
+++ b/guests/op-derive/Cargo.toml
@@ -6,7 +6,7 @@ edition = "2021"
 [workspace]
 
 [dependencies]
-risc0-zkvm = { version = "1.0.0-rc.3", default-features = false, features = ['std'] }
+risc0-zkvm = { version = "1.0.0-rc.5", default-features = false, features = ['std'] }
 zeth-lib = { path = "../../lib", default-features = false }
 
 [patch.crates-io]

--- a/host/src/cli.rs
+++ b/host/src/cli.rs
@@ -177,6 +177,10 @@ pub struct RunArgs {
     #[clap(short, long, default_value_t = false)]
     /// Whether to profile the zkVM execution
     pub profile: bool,
+
+    /// Optionally export cycles from executing in csv format to the file path.
+    #[clap(long, require_equals = true)]
+    pub export_csv: Option<PathBuf>,
 }
 
 impl Tag for RunArgs {

--- a/host/src/operations/mod.rs
+++ b/host/src/operations/mod.rs
@@ -24,7 +24,7 @@ use risc0_zkvm::{
     compute_image_id,
     serde::to_vec,
     sha::{Digest, Digestible},
-    Assumption, ExecutorEnv, ExecutorImpl, Receipt, Segment, SegmentRef,
+    Assumption, ExecutorEnv, ExecutorImpl, Receipt, Segment, SegmentRef, Session,
 };
 use serde::{de::DeserializeOwned, Deserialize, Serialize};
 use zeth_primitives::keccak::keccak;
@@ -353,7 +353,7 @@ pub fn execute<T: Serialize, O: Eq + Debug + DeserializeOwned>(
     elf: &[u8],
     expected_output: &O,
     profile_reference: &String,
-) {
+) -> Session {
     debug!(
         "Running in executor with segment_limit_po2 = {:?}",
         segment_limit_po2
@@ -390,7 +390,7 @@ pub fn execute<T: Serialize, O: Eq + Debug + DeserializeOwned>(
         session.segments.len() * (1 << segment_limit_po2)
     );
     // verify output
-    let journal = session.journal.unwrap();
+    let journal = session.journal.as_ref().unwrap();
     let output_guest: O = journal.decode().expect("Could not decode journal");
     if expected_output == &output_guest {
         info!("Executor succeeded");
@@ -400,4 +400,6 @@ pub fn execute<T: Serialize, O: Eq + Debug + DeserializeOwned>(
             output_guest, expected_output,
         );
     }
+
+    session
 }

--- a/lib/Cargo.toml
+++ b/lib/Cargo.toml
@@ -14,7 +14,7 @@ hashbrown = { workspace = true }
 libflate = "2.0.0"
 once_cell = "1.18"
 revm = { workspace = true }
-risc0-zkvm = { version = "1.0.0-rc.3", default-features = false, features = ['std'] }
+risc0-zkvm = { version = "1.0.0-rc.5", default-features = false, features = ['std'] }
 ruint = { version = "1.10", default-features = false }
 serde = "1.0"
 thiserror = "1.0"

--- a/testing/ef-tests/testguest/Cargo.lock
+++ b/testing/ef-tests/testguest/Cargo.lock
@@ -1682,17 +1682,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "51d515d32fb182ee37cda2ccdcb92950d6a3c2893aa280e540671c2cd0f3b1d9"
 
 [[package]]
-name = "num-derive"
-version = "0.4.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ed3955f1a9c7c0c15e092f9c887db08b1fc683305fdf6eb6684f22555355e202"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn 2.0.48",
-]
-
-[[package]]
 name = "num-integer"
 version = "0.1.46"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2293,9 +2282,9 @@ dependencies = [
 
 [[package]]
 name = "risc0-binfmt"
-version = "1.0.0-rc.3"
+version = "1.0.0-rc.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e0bf2b3120d663dc0f1295c26c40c0bb22774a0bea3409adaa6cf0de5cadf518"
+checksum = "174598af56aad42537c50d05c226cc7e346f8fda5f1fbe39ded52836fed3753e"
 dependencies = [
  "anyhow",
  "elf",
@@ -2307,9 +2296,9 @@ dependencies = [
 
 [[package]]
 name = "risc0-circuit-recursion"
-version = "1.0.0-rc.3"
+version = "1.0.0-rc.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "45ac9b0ab1b097a76e11c1bd265e145ab8e0f4d54e37b94f596fabf92a1ee289"
+checksum = "f4bf5ca899bb3650a9eed60450795a749925b5eb09a29e8a7fb8ef3122034ac6"
 dependencies = [
  "anyhow",
  "bytemuck",
@@ -2321,9 +2310,9 @@ dependencies = [
 
 [[package]]
 name = "risc0-circuit-rv32im"
-version = "1.0.0-rc.3"
+version = "1.0.0-rc.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "17da0fb133b11710cc65e96e711765ff9962611ce21fc0d325bb3fb9fd5e39ab"
+checksum = "ec21b15f8dcccf0826e0ea5a6efbb572b1c324d24c7c011d5b1ebf7201b47dbb"
 dependencies = [
  "anyhow",
  "risc0-binfmt",
@@ -2336,9 +2325,9 @@ dependencies = [
 
 [[package]]
 name = "risc0-core"
-version = "1.0.0-rc.3"
+version = "1.0.0-rc.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "23a015abc51d21f6a2f05968597e86492618722f5a4db961225f7fb674b45812"
+checksum = "2e69e8ea72d38052b349e1598cb229d3f965bac6b1134b00f05ef090c792a42b"
 dependencies = [
  "bytemuck",
  "rand_core",
@@ -2346,31 +2335,34 @@ dependencies = [
 
 [[package]]
 name = "risc0-groth16"
-version = "1.0.0-rc.3"
+version = "1.0.0-rc.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b61c1e15b5d586f7c987d9ca3a1dfb888855c7b8ad0ffb097f8bfa89a01773ad"
+checksum = "313483931948778b91ea105c115ccc833f4b058649fb13f1b36f99325e04f0e8"
 dependencies = [
  "anyhow",
  "ark-bn254",
+ "ark-ec",
  "ark-groth16",
  "ark-serialize 0.4.2",
+ "bytemuck",
  "hex",
  "num-bigint",
- "num-derive",
  "num-traits",
+ "risc0-binfmt",
  "risc0-zkp",
  "serde",
 ]
 
 [[package]]
 name = "risc0-zkp"
-version = "1.0.0-rc.3"
+version = "1.0.0-rc.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "44a10836da64aabb816ac7d812718cb461b6f43e7c58847e5b36a2a9a60a8132"
+checksum = "488a3d73143affc2ccae0e2619790c6ab44f794591923b5f0e7df1ede09c8509"
 dependencies = [
  "anyhow",
  "blake2",
  "bytemuck",
+ "cfg-if",
  "digest 0.10.7",
  "hex",
  "paste",
@@ -2384,9 +2376,9 @@ dependencies = [
 
 [[package]]
 name = "risc0-zkvm"
-version = "1.0.0-rc.3"
+version = "1.0.0-rc.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a6f4f516803fa363f7ce877f61716dfe0dcd293317e54fb76ed3f71419bcb297"
+checksum = "749eaa5169256cabc910e2143d2fcaf25c465dc9e348fd7e01b696f02d19d957"
 dependencies = [
  "anyhow",
  "bytemuck",
@@ -2409,9 +2401,9 @@ dependencies = [
 
 [[package]]
 name = "risc0-zkvm-platform"
-version = "1.0.0-rc.3"
+version = "1.0.0-rc.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b87b12fd67bdd81e69506b571ab55eb8f52b2d8a22c8a4aeb249ceea84ade971"
+checksum = "20e006ec91eecbff9c0849a9028c5558495292d333d3a0841e35db0f77baf3fb"
 dependencies = [
  "bytemuck",
  "getrandom",

--- a/testing/ef-tests/testguest/Cargo.toml
+++ b/testing/ef-tests/testguest/Cargo.toml
@@ -6,7 +6,7 @@ edition = "2021"
 [workspace]
 
 [dependencies]
-risc0-zkvm = { version = "1.0.0-rc.3", default-features = false, features = ['std'] }
+risc0-zkvm = { version = "1.0.0-rc.5", default-features = false, features = ['std'] }
 zeth-lib = { path = "../../../lib", default-features = false }
 
 [patch.crates-io]


### PR DESCRIPTION
Don't look at this, just committing some hacky/wip code to be able to bench block cycle counts.

Although https://github.com/risc0/zeth/commit/5589bcaaf49dec793e53bb6730b5786548cbdefd might be useful as it moves toward proving ranges (but could be done better/cleaned up if so)


Command I'm running (for my own reference)
```console
zeth run --export-csv=<output file> --block-number=19000000 --block-count=10 --eth-rpc-url=<url>
```