### PR TITLE
Perf: load code by hash

### DIFF
--- a/crates/core/src/stateless/data.rs
+++ b/crates/core/src/stateless/data.rs
@@ -35,7 +35,7 @@ pub struct StatelessClientData<Block, Header> {
     /// Maps each address with its storage trie and the used storage slots.
     pub storage_tries: HashMap<Address, StorageEntry>,
     /// The code for each account
-    pub contracts: HashMap<Address, Bytes>,
+    pub contracts: Vec<Bytes>,
     /// Immediate parent header
     pub parent_header: Header,
     /// List of at most 256 previous block headers

--- a/crates/preflight/src/client.rs
+++ b/crates/preflight/src/client.rs
@@ -20,6 +20,7 @@ use crate::provider::{new_provider, Provider};
 use crate::trie::extend_proof_tries;
 use alloy::network::Network;
 use alloy::primitives::map::HashMap;
+use alloy::primitives::Bytes;
 use anyhow::Context;
 use log::{debug, info, warn};
 use std::cell::RefCell;
@@ -167,7 +168,7 @@ where
         let core_parent_header = P::derive_header(data.parent_header.clone());
         let mut state_trie = MptNode::from(R::state_root(&core_parent_header));
         let mut storage_tries = Default::default();
-        let mut contracts = data.contracts.clone();
+        let mut contracts: Vec<Bytes> = Default::default();
         let mut ancestor_headers: Vec<R::Header> = Default::default();
 
         for num_blocks in 1..=block_count {
@@ -221,11 +222,8 @@ where
             // collect the code from each account
             info!("Collecting contracts ...");
             let initial_db = preflight_db.inner.db.db.borrow();
-            for (address, account) in initial_db.accounts.iter() {
-                let code = account.info.code.clone().context("missing code")?;
-                if !code.is_empty() && !contracts.contains_key(address) {
-                    contracts.insert(*address, code.bytes());
-                }
+            for code in initial_db.contracts.values() {
+                contracts.push(code.bytes().clone());
             }
             drop(initial_db);
 

--- a/crates/preflight/src/client.rs
+++ b/crates/preflight/src/client.rs
@@ -219,13 +219,13 @@ where
             info!("Saving provider cache ...");
             preflight_db.save_provider()?;
 
-            // collect the code from each account
-            info!("Collecting contracts ...");
+            // collect the code of the used contracts
             let initial_db = preflight_db.inner.db.db.borrow();
             for code in initial_db.contracts.values() {
                 contracts.push(code.bytes().clone());
             }
             drop(initial_db);
+            info!("Collected contracts: {}", contracts.len());
 
             // construct the sparse MPTs from the inclusion proofs
             info!(

--- a/crates/preflight/src/provider/db.rs
+++ b/crates/preflight/src/provider/db.rs
@@ -19,7 +19,7 @@ use alloy::network::Network;
 use alloy::primitives::map::HashMap;
 use alloy::primitives::{Address, B256, U256};
 use reth_revm::primitives::{Account, AccountInfo, Bytecode};
-use reth_revm::{Database, DatabaseCommit, DatabaseRef};
+use reth_revm::{Database, DatabaseCommit};
 use reth_storage_errors::db::DatabaseError;
 use std::cell::RefCell;
 use std::marker::PhantomData;
@@ -29,6 +29,9 @@ use zeth_core::driver::CoreDriver;
 pub struct ProviderDB<N: Network, R: CoreDriver, P: PreflightDriver<R, N>> {
     pub provider: Rc<RefCell<dyn Provider<N>>>,
     pub block_no: u64,
+    /// Bytecode cache to allow querying bytecode by hash instead of address.
+    pub contracts: HashMap<B256, Bytecode>,
+
     pub driver: PhantomData<(R, P)>,
 }
 
@@ -37,6 +40,7 @@ impl<N: Network, R: CoreDriver, P: PreflightDriver<R, N>> Clone for ProviderDB<N
         Self {
             provider: self.provider.clone(),
             block_no: self.block_no,
+            contracts: self.contracts.clone(),
             driver: self.driver,
         }
     }
@@ -47,6 +51,7 @@ impl<N: Network, R: CoreDriver, P: PreflightDriver<R, N>> ProviderDB<N, R, P> {
         ProviderDB {
             provider,
             block_no,
+            contracts: HashMap::default(),
             driver: PhantomData,
         }
     }
@@ -62,55 +67,9 @@ impl<N: Network, R: CoreDriver, P: PreflightDriver<R, N>> ProviderDB<N, R, P> {
 }
 
 impl<N: Network, R: CoreDriver, P: PreflightDriver<R, N>> Database for ProviderDB<N, R, P> {
-    type Error = anyhow::Error;
-
-    fn basic(&mut self, address: Address) -> Result<Option<AccountInfo>, Self::Error> {
-        let query = AccountQuery {
-            block_no: self.block_no,
-            address: address.into_array().into(),
-        };
-        let nonce = self.provider.borrow_mut().get_transaction_count(&query)?;
-        let balance = self.provider.borrow_mut().get_balance(&query)?;
-        let code = self.provider.borrow_mut().get_code(&query)?;
-        let bytecode = Bytecode::new_raw(code);
-        Ok(Some(AccountInfo::new(
-            balance,
-            nonce.to(),
-            bytecode.hash_slow(),
-            bytecode,
-        )))
-    }
-
-    fn code_by_hash(&mut self, code_hash: B256) -> Result<Bytecode, Self::Error> {
-        // not needed because we already load code with basic info
-        unreachable!("ProviderDB::code_by_hash {code_hash}")
-    }
-
-    fn storage(&mut self, address: Address, index: U256) -> Result<U256, Self::Error> {
-        let bytes = index.to_be_bytes::<32>();
-        let index = U256::from_be_bytes(bytes);
-
-        self.provider.borrow_mut().get_storage(&StorageQuery {
-            block_no: self.block_no,
-            address: address.into_array().into(),
-            index,
-        })
-    }
-
-    fn block_hash(&mut self, block_no: u64) -> Result<B256, Self::Error> {
-        let header = P::derive_header(P::derive_header_response(
-            self.provider
-                .borrow_mut()
-                .get_full_block(&BlockQuery { block_no })?,
-        ));
-        Ok(R::header_hash(&header))
-    }
-}
-
-impl<N: Network, R: CoreDriver, P: PreflightDriver<R, N>> DatabaseRef for ProviderDB<N, R, P> {
     type Error = DatabaseError;
 
-    fn basic_ref(&self, address: Address) -> Result<Option<AccountInfo>, Self::Error> {
+    fn basic(&mut self, address: Address) -> Result<Option<AccountInfo>, Self::Error> {
         let query = AccountQuery {
             block_no: self.block_no,
             address: address.into_array().into(),
@@ -119,44 +78,61 @@ impl<N: Network, R: CoreDriver, P: PreflightDriver<R, N>> DatabaseRef for Provid
             .provider
             .borrow_mut()
             .get_transaction_count(&query)
-            .unwrap();
-        let balance = self.provider.borrow_mut().get_balance(&query).unwrap();
-        let code = self.provider.borrow_mut().get_code(&query).unwrap();
+            .map_err(db_error)?;
+        let balance = self
+            .provider
+            .borrow_mut()
+            .get_balance(&query)
+            .map_err(db_error)?;
+        let code = self
+            .provider
+            .borrow_mut()
+            .get_code(&query)
+            .map_err(db_error)?;
         let bytecode = Bytecode::new_raw(code);
-        Ok(Some(AccountInfo::new(
+
+        // index the code by its hash, so that we can later use code_by_hash
+        let code_hash = bytecode.hash_slow();
+        self.contracts.insert(code_hash, bytecode);
+
+        Ok(Some(AccountInfo {
+            nonce: nonce.to(),
             balance,
-            nonce.to(),
-            bytecode.hash_slow(),
-            bytecode,
-        )))
+            code_hash,
+            code: None, // will be queried later using code_by_hash
+        }))
     }
 
-    fn code_by_hash_ref(&self, code_hash: B256) -> Result<Bytecode, Self::Error> {
-        // not needed because we already load code with basic info
-        unreachable!("ProviderDB::code_by_hash_ref {code_hash}")
+    fn code_by_hash(&mut self, code_hash: B256) -> Result<Bytecode, Self::Error> {
+        // this works because `basic` is always called first
+        let code = self
+            .contracts
+            .get(&code_hash)
+            .expect("`basic` must be called first for the corresponding account");
+
+        Ok(code.clone())
     }
 
-    fn storage_ref(&self, address: Address, index: U256) -> Result<U256, Self::Error> {
+    fn storage(&mut self, address: Address, index: U256) -> Result<U256, Self::Error> {
         let bytes = index.to_be_bytes::<32>();
         let index = U256::from_be_bytes(bytes);
 
-        Ok(self
-            .provider
+        self.provider
             .borrow_mut()
             .get_storage(&StorageQuery {
                 block_no: self.block_no,
                 address: address.into_array().into(),
                 index,
             })
-            .unwrap())
+            .map_err(db_error)
     }
 
-    fn block_hash_ref(&self, block_no: u64) -> Result<B256, Self::Error> {
+    fn block_hash(&mut self, block_no: u64) -> Result<B256, Self::Error> {
         let header = P::derive_header(P::derive_header_response(
             self.provider
                 .borrow_mut()
                 .get_full_block(&BlockQuery { block_no })
-                .unwrap(),
+                .map_err(db_error)?,
         ));
         Ok(R::header_hash(&header))
     }
@@ -164,4 +140,8 @@ impl<N: Network, R: CoreDriver, P: PreflightDriver<R, N>> DatabaseRef for Provid
 
 impl<N: Network, R: CoreDriver, P: PreflightDriver<R, N>> DatabaseCommit for ProviderDB<N, R, P> {
     fn commit(&mut self, _changes: HashMap<Address, Account>) {}
+}
+
+fn db_error(err: anyhow::Error) -> DatabaseError {
+    DatabaseError::Other(format!("provider error: {err:#}"))
 }


### PR DESCRIPTION
Instead of adding the contract bytecode to each account, load the code only when needed. 

When a contract is actually used, revm calls `code_by_hash` to load the appropriate bytecode.
This has several small performance benefits:
- All contracts in the input can be stored in a vector instead of a hash map.
- Duplicate contracts are only stored once.
- Contracts from accounts that don't actually read the code don't need to be included or copied.

With these changes, the ProviderDB needs to be mutable during database calls, so we wrap it in a RefCell using the cleaned up MutDB.