### PR TITLE
refactor: Clap attribute macros from #[clap(...)] to #[arg(...)] and #[command(...)] in v4.x

### DIFF
--- a/bin/benchmark/src/main.rs
+++ b/bin/benchmark/src/main.rs
@@ -19,15 +19,15 @@ use std::process::Command;
 use tracing::{error, info};
 use zeth::cli::ProveArgs;
 
-#[derive(clap::Parser, Debug, Clone)]
+#[derive(Parser, Debug, Clone)]
 #[command(name = "zeth-benchmark")]
 #[command(bin_name = "zeth-benchmark")]
 #[command(author, version, about, long_about = None)]
 pub struct Cli {
-    #[clap(flatten)]
+    #[command(flatten)]
     pub prove_args: ProveArgs,
 
-    #[clap(
+    #[arg(
         long,
         require_equals = true,
         value_enum,
@@ -37,16 +37,16 @@ pub struct Cli {
     /// Which chain spec to use.
     pub chain_id: Option<NamedChain>,
 
-    #[clap(long, require_equals = true)]
+    #[arg(long, require_equals = true)]
     /// The range of blocks after the starting block number to sample from
     pub sample_range: u64,
 
-    #[clap(long, require_equals = true)]
+    #[arg(long, require_equals = true)]
     /// The number of samples to benchmark
     pub sample_count: u64,
 
     /// Path to the zeth program used for proving
-    #[clap(long, require_equals = true)]
+    #[arg(long, require_equals = true)]
     pub zeth: Option<String>,
 }
 

--- a/crates/zeth/src/cli.rs
+++ b/crates/zeth/src/cli.rs
@@ -12,12 +12,12 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use clap::ValueEnum;
+use clap::{Parser, Args, ValueEnum, Command};
 use reth_chainspec::NamedChain;
 use std::fmt::{Display, Formatter};
 use std::path::PathBuf;
 
-#[derive(clap::Parser, Debug, Clone)]
+#[derive(Parser, Debug, Clone)]
 #[command(name = "zeth")]
 #[command(bin_name = "zeth")]
 #[command(author, version, about, long_about = None)]
@@ -110,7 +110,7 @@ pub struct BuildArgs {
     pub chain: Option<NamedChain>,
 }
 
-#[derive(Debug, Clone, clap::ValueEnum, Hash, Ord, PartialOrd, Eq, PartialEq)]
+#[derive(Debug, Clone, ValueEnum, Hash, Ord, PartialOrd, Eq, PartialEq)]
 pub enum Chain {
     /// Mainnet
     Mainnet,
@@ -130,7 +130,7 @@ impl Display for Chain {
     }
 }
 
-#[derive(clap::Args, Debug, Clone)]
+#[derive(Args, Debug, Clone)]
 pub struct RunArgs {
     #[arg(flatten)]
     pub build_args: BuildArgs,
@@ -144,7 +144,7 @@ pub struct RunArgs {
     pub profile: bool,
 }
 
-#[derive(clap::Args, Debug, Clone)]
+#[derive(Args, Debug, Clone)]
 pub struct ProveArgs {
     #[arg(flatten)]
     pub run_args: RunArgs,
@@ -154,7 +154,7 @@ pub struct ProveArgs {
     pub snark: bool,
 }
 
-#[derive(clap::Args, Debug, Clone)]
+#[derive(Args, Debug, Clone)]
 pub struct VerifyArgs {
     #[arg(flatten)]
     pub build_args: BuildArgs,

--- a/crates/zeth/src/cli.rs
+++ b/crates/zeth/src/cli.rs
@@ -85,27 +85,27 @@ impl Cli {
     }
 }
 
-#[derive(clap::Args, Debug, Clone)]
+#[derive(Debug, Clone, Args)]
 pub struct BuildArgs {
-    #[clap(short = 'u', long, require_equals = true)]
+    #[arg(short = 'u', long, require_equals = true)]
     /// URL of the execution-layer RPC node
     pub rpc: Option<String>,
 
-    #[clap(short = 'd', long, require_equals = true, num_args = 0..=1, default_missing_value = "cache_rpc")]
+    #[arg(short = 'd', long, require_equals = true, num_args = 0..=1, default_missing_value = "cache_rpc")]
     /// Directory for caching RPC data; the value specifies the cache directory
     ///
     /// [default when the flag is present: cache_rpc]
     pub cache: Option<PathBuf>,
 
-    #[clap(short = 'b', long, require_equals = true)]
+    #[arg(short = 'b', long, require_equals = true)]
     /// Starting block number
     pub block_number: u64,
 
-    #[clap(short = 'n', long, require_equals = true, default_value_t = 1)]
+    #[arg(short = 'n', long, require_equals = true, default_value_t = 1)]
     /// Number of blocks to build in a single proof
     pub block_count: u64,
 
-    #[clap(short = 'c', long, require_equals = true, value_enum)]
+    #[arg(short = 'c', long, require_equals = true, value_enum)]
     /// Which chain spec to use.
     pub chain: Option<NamedChain>,
 }
@@ -132,34 +132,34 @@ impl Display for Chain {
 
 #[derive(clap::Args, Debug, Clone)]
 pub struct RunArgs {
-    #[clap(flatten)]
+    #[arg(flatten)]
     pub build_args: BuildArgs,
 
-    #[clap(short = 'e', long, require_equals = true, default_value_t = 20)]
+    #[arg(short = 'e', long, require_equals = true, default_value_t = 20)]
     /// The maximum cycle count of a segment as a power of 2
     pub execution_po2: u32,
 
-    #[clap(short = 'p', long, default_value_t = false)]
-    /// Save the profile of the execution in the current working directly
+    #[arg(short = 'p', long, default_value_t = false)]
+    /// Save the profile of the execution in the current working directory
     pub profile: bool,
 }
 
 #[derive(clap::Args, Debug, Clone)]
 pub struct ProveArgs {
-    #[clap(flatten)]
+    #[arg(flatten)]
     pub run_args: RunArgs,
 
-    #[clap(short = 's', long, default_value_t = false)]
+    #[arg(short = 's', long, default_value_t = false)]
     /// Convert the resulting STARK receipt into a Groth-16 SNARK
     pub snark: bool,
 }
 
 #[derive(clap::Args, Debug, Clone)]
 pub struct VerifyArgs {
-    #[clap(flatten)]
+    #[arg(flatten)]
     pub build_args: BuildArgs,
 
-    #[clap(short = 'f', long, require_equals = true)]
+    #[arg(short = 'f', long, require_equals = true)]
     /// Receipt file path
     pub file: PathBuf,
 }

--- a/crates/zeth/src/cli.rs
+++ b/crates/zeth/src/cli.rs
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use clap::{Parser, Args, ValueEnum, Command};
+use clap::{Args, Command, Parser, ValueEnum};
 use reth_chainspec::NamedChain;
 use std::fmt::{Display, Formatter};
 use std::path::PathBuf;
@@ -132,7 +132,7 @@ impl Display for Chain {
 
 #[derive(Args, Debug, Clone)]
 pub struct RunArgs {
-    #[arg(flatten)]
+    #[command(flatten)]
     pub build_args: BuildArgs,
 
     #[arg(short = 'e', long, require_equals = true, default_value_t = 20)]
@@ -146,7 +146,7 @@ pub struct RunArgs {
 
 #[derive(Args, Debug, Clone)]
 pub struct ProveArgs {
-    #[arg(flatten)]
+    #[command(flatten)]
     pub run_args: RunArgs,
 
     #[arg(short = 's', long, default_value_t = false)]
@@ -156,7 +156,7 @@ pub struct ProveArgs {
 
 #[derive(Args, Debug, Clone)]
 pub struct VerifyArgs {
-    #[arg(flatten)]
+    #[command(flatten)]
     pub build_args: BuildArgs,
 
     #[arg(short = 'f', long, require_equals = true)]


### PR DESCRIPTION
This PR updates deprecated `#[clap(...)]` attributes to their modern equivalents in `clap` 4.x.
The current codebase still uses outdated syntax that has been deprecated since version 4.0.
By making this update, we ensure compatibility with future versions and maintain code quality.

Fixes #152 

Build Result : 
![image](https://github.com/user-attachments/assets/af3f40e5-86ed-42c5-ad41-4e07cd4ef174)

Test Result : 
![Pasted Graphic 46](https://github.com/user-attachments/assets/31ed4902-ecc1-4fa5-939c-0135ce4d82fc)

I encountered only one error, which is not related to my PR:
![Pasted Graphic 45](https://github.com/user-attachments/assets/f3ef4c47-73ff-470a-a703-20d96a9825f3)


