### PR TITLE
Update rust-toolchain.toml

### DIFF
--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,4 +1,4 @@
 [toolchain]
-channel = "1.83"
+channel = "1.85"
 components = ["clippy", "rustfmt", "rust-src"]
 profile = "minimal"

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,4 +1,4 @@
 [toolchain]
-channel = "1.81"
+channel = "1.83"
 components = ["clippy", "rustfmt", "rust-src"]
 profile = "minimal"


### PR DESCRIPTION
in main I am getting this error from `cargo build -p zeth-ethereum --bin zeth-ethereum`:

```bash
  Downloaded alloy-json-rpc v0.4.2
error: rustc 1.81.0 is not supported by the following packages:
  malachite@0.4.22 requires rustc 1.83.0
  malachite-base@0.4.22 requires rustc 1.83.0
  malachite-float@0.4.22 requires rustc 1.83.0
  malachite-nz@0.4.22 requires rustc 1.83.0
  malachite-nz@0.4.22 requires rustc 1.83.0
  malachite-nz@0.4.22 requires rustc 1.83.0
  malachite-q@0.4.22 requires rustc 1.83.0
Either upgrade rustc or select compatible dependency versions with
`cargo update <name>@<current-ver> --precise <compatible-ver>`
where `<compatible-ver>` is the latest version supporting rustc 1.81.0
```

this pr is to update the toolchain of rust to 1.83 in order to alleviate this error.