### PR TITLE
cleanup cargo fmt error

### DIFF
--- a/crates/zeth/src/cli.rs
+++ b/crates/zeth/src/cli.rs
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use clap::{Args, Command, Parser, ValueEnum};
+use clap::{Args, Parser, ValueEnum};
 use reth_chainspec::NamedChain;
 use std::fmt::{Display, Formatter};
 use std::path::PathBuf;


### PR DESCRIPTION
addresses:
```
   Compiling zeth v0.1.0 (/opt/actions-runner/_work/competitive-benchmarks/competitive-benchmarks/zeth/crates/zeth)
warning: unused import: `Command`
  --> crates/zeth/src/cli.rs:15:18
   |
15 | use clap::{Args, Command, Parser, ValueEnum};
   |                  ^^^^^^^
   |
   = note: `#[warn(unused_imports)]` on by default
warning: `zeth` (lib) generated 1 warning (run `cargo fix --lib -p zeth` to apply 1 suggestion)
   Compiling zeth-ethereum v0.1.0 (/opt/actions-runner/_work/competitive-benchmarks/competitive-benchmarks/zeth/bin/ethereum)
    Finished `dev` profile [optimized] target(s) in 3m 47s
    ```