### PR TITLE
Update .gitmodules

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,3 @@
 [submodule "testing/ef-tests/testdata"]
 	path = testing/ef-tests/testdata
-	url = https://github.com/ethereum/tests.git
+	url = https://github.com/ethereum/tests


### PR DESCRIPTION
without .git is correct. Github stop use .git at the end