### PR TITLE
feat: Add `unsafe-pre-merge` feature for pre-merge blocks

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### ⚡️ Features
+
+- New feature `unsafe-pre-merge` must be enabled to prove pre-merge blocks.
+
 ## [0.2.1](https://github.com/risc0/zeth/releases/tag/v0.2.1) - 2025-08-05
 
 - Fix wrong journal decoding in `cli`

--- a/README.md
+++ b/README.md
@@ -108,6 +108,17 @@ ETH_RPC_URL="<YOUR_RPC_URL>" cargo run --release --bin cli -- prove
 RISC0_DEV_MODE=1 ETH_RPC_URL="<YOUR_RPC_URL>" cargo run --release --bin cli -- prove 19000000
 ```
 
+#### Proving Pre-Merge (Proof-of-Work) Blocks
+
+By default, Zeth only supports proving post-merge (Proof-of-Stake) blocks. This is because the underlying `reth-stateless` library does not fully validate the total difficulty, making proofs of pre-merge blocks underconstrained.
+
+For development and research purposes, you can enable the proving of historical blocks by using the `unsafe-pre-merge` feature flag:
+```bash
+ETH_RPC_URL="<YOUR_RPC_URL>" cargo run --release --bin cli --features "unsafe-pre-merge" -- prove --block 1
+```
+
+**Warning**: Proofs generated with this flag are not fully sound and should not be used in production.
+
 ## Additional Resources
 
 * [RISC Zero Developer Portal](https://dev.risczero.com/)

--- a/crates/core/Cargo.toml
+++ b/crates/core/Cargo.toml
@@ -18,3 +18,6 @@ reth-stateless = { workspace = true }
 reth-trie-common = { workspace = true }
 revm-bytecode = { workspace = true }
 risc0-ethereum-trie = { workspace = true }
+
+[features]
+unsafe-pre-merge = []

--- a/crates/core/Cargo.toml
+++ b/crates/core/Cargo.toml
@@ -20,4 +20,6 @@ revm-bytecode = { workspace = true }
 risc0-ethereum-trie = { workspace = true }
 
 [features]
+# Allow proving of pre-merge (Proof-of-Work) blocks.
+# This is considered unsafe because reth does not correctly validate all difficulty constraints.
 unsafe-pre-merge = []

--- a/crates/core/src/lib.rs
+++ b/crates/core/src/lib.rs
@@ -39,11 +39,16 @@ pub fn validate_block<C>(
 where
     C: EthExecutorSpec + EthChainSpec<Header = Header> + Hardforks + 'static,
 {
+    let chain_spec = config.chain_spec().clone();
+
+    #[cfg(not(feature = "unsafe-pre-merge"))]
+    assert!(
+        reth_chainspec::EthereumHardforks::is_paris_active_at_block(&chain_spec, block.number),
+        "only post-merge blocks supported"
+    );
+
     reth_stateless::stateless_validation_with_trie::<SparseState, _, _>(
-        block,
-        witness,
-        config.chain_spec().clone(),
-        config,
+        block, witness, chain_spec, config,
     )
 }
 

--- a/crates/host/Cargo.toml
+++ b/crates/host/Cargo.toml
@@ -18,3 +18,6 @@ risc0-zkvm = { workspace = true }
 serde_json = { workspace = true }
 tokio = { workspace = true }
 zeth-core = { workspace = true }
+
+[features]
+unsafe-pre-merge = ["guests/unsafe-pre-merge", "zeth-core/unsafe-pre-merge"]

--- a/guests/Cargo.toml
+++ b/guests/Cargo.toml
@@ -9,3 +9,6 @@ risc0-build = { workspace = true }
 
 [package.metadata.risc0]
 methods = ["stateless-client"]
+
+[features]
+unsafe-pre-merge = []

--- a/guests/build.rs
+++ b/guests/build.rs
@@ -30,6 +30,10 @@ fn main() {
 
     let mut guest_opts = GuestOptionsBuilder::default();
 
+    // pass the unsafe-pre-merge feature through to the guest
+    #[cfg(feature = "unsafe-pre-merge")]
+    guest_opts.features(vec!["unsafe-pre-merge".to_string()]);
+
     // Use Docker for deterministic builds if RISC0_USE_DOCKER is set.
     if env::var("RISC0_USE_DOCKER").is_ok() {
         let docker_tag = format!("r0.{RISC0_RUST_VERSION}");

--- a/guests/stateless-client/Cargo.toml
+++ b/guests/stateless-client/Cargo.toml
@@ -12,13 +12,16 @@ lto = "fat"
 [dependencies]
 blst = { version = "=0.3.15" }
 c-kzg = { version = "=2.1.1" }
-zeth-chainspec = { path = "../../crates/chainspec" }
-zeth-core = { path = "../../crates/core" }
 revm = { version = "27.1", default-features = false, features = ["std", "c-kzg", "portable", "blst", "bn"] }
 risc0-zkvm = { version = "2.3", features = ["unstable"] }
 sha2 = { version = "=0.10.9" }
 substrate-bn = { version = "=0.6.0" }
 tiny-keccak = { version = "=2.0.2" }
+zeth-chainspec = { path = "../../crates/chainspec" }
+zeth-core = { path = "../../crates/core" }
+
+[features]
+unsafe-pre-merge = ["zeth-core/unsafe-pre-merge"]
 
 [patch.crates-io]
 blst = { git = "https://github.com/risc0/blst", tag = "v0.3.15-risczero.0" }


### PR DESCRIPTION
This PR introduces an unsafe-pre-merge feature flag to allow proving pre-merge (Proof-of-Work) blocks.

By default, reth-stateless does not correctly validate all difficulty constraints for these blocks, making the proofs unsound. This feature disables the default post-merge block check, enabling users to generate proofs for historical blocks at their own risk.

The feature is propagated from the zeth-host crate down to the guest binary to ensure consistent validation logic between the host and zkVM.