### PR TITLE
chore: fix comment grammar in preflight DB

### DIFF
--- a/crates/rpc-proxy/src/db/preflight.rs
+++ b/crates/rpc-proxy/src/db/preflight.rs
@@ -70,7 +70,7 @@ struct AccountProof {
 struct StorageProof {
     /// The value that this key holds.
     value: StorageValue,
-    /// In MPT inclusion proof for this particular slot.
+    /// An MPT inclusion proof for this particular slot.
     proof: Vec<Bytes>,
 }
 


### PR DESCRIPTION
- fix a small grammar issue in a `PreflightDb` storage proof comment
- keep the change limited to documentation/comments
- make no behavior or API changes
